### PR TITLE
Share autoconnect logic

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -32,6 +32,7 @@ import json
 import tempfile
 from pathlib import Path
 from collections import defaultdict
+import autoconnect
 try:
     import generate_report
 except Exception as exc:  # pragma: no cover - optional dependency
@@ -2821,7 +2822,8 @@ app.layout = html.Div([
 
 ], className="main-app-container")
 from callbacks import register_callbacks
-register_callbacks(app)
+if __name__ == "__main__":
+    register_callbacks(app)
 
 def load_historical_data(timeframe="24h", machine_id=None):
     """Load historical counter data for the requested timeframe and machine.
@@ -4799,15 +4801,10 @@ if __name__ == "__main__":
         args = parser.parse_args()
 
         logger.info("Starting dashboard application...")
-        
-        logger.info("About to start auto-reconnection thread...")
-        start_auto_reconnection()
-        logger.info("Auto-reconnection thread start command completed")
+        register_callbacks(app)
 
-        startup_thread = Thread(target=delayed_startup_connect)
-        startup_thread.daemon = True
-        startup_thread.start()
-        logger.info("Scheduled startup auto-connection...")
+        logger.info("Initializing auto-connect logic...")
+        autoconnect.initialize_autoconnect()
 
         saved_image = load_saved_image()
         if saved_image:

--- a/autoconnect.py
+++ b/autoconnect.py
@@ -1,0 +1,117 @@
+import logging
+from threading import Thread
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+# Functions copied from the original dashboard script
+
+def start_auto_reconnection():
+    """Start the auto-reconnection thread"""
+    if not hasattr(app_state, 'reconnection_thread') or not app_state.reconnection_thread.is_alive():
+        app_state.reconnection_thread = Thread(target=auto_reconnection_thread)
+        app_state.reconnection_thread.daemon = True
+        app_state.reconnection_thread.start()
+        logger.info("Started auto-reconnection thread")
+
+
+def startup_auto_connect_machines():
+    """Automatically connect to all machines on startup"""
+    try:
+        # Load saved machines data
+        floors_data, machines_data = load_floor_machine_data()
+
+        if not machines_data or not machines_data.get("machines"):
+            logger.info("No machines found for auto-connection")
+            return
+
+        machines = machines_data.get("machines", [])
+        connected_count = 0
+
+        logger.info(f"Attempting to auto-connect to {len(machines)} machines on startup...")
+
+        for machine in machines:
+            machine_id = machine.get("id")
+            machine_ip = machine.get("selected_ip") or machine.get("ip")
+
+            if not machine_ip:
+                logger.info(f"Skipping machine {machine_id} - no IP address configured")
+                continue
+
+            if machine_id in machine_connections:
+                logger.info(f"Machine {machine_id} already connected, skipping")
+                continue
+
+            try:
+                logger.info(f"Auto-connecting to machine {machine_id} at {machine_ip}...")
+
+                # Create a new event loop for this thread
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+                try:
+                    # Use the existing connect function with proper async handling
+                    connection_success = loop.run_until_complete(
+                        connect_and_monitor_machine(machine_ip, machine_id, "Satake.EvoRGB.1")
+                    )
+
+                    if connection_success:
+                        logger.info(f"✓ Successfully auto-connected to machine {machine_id}")
+                        connected_count += 1
+                    else:
+                        logger.warning(f"✗ Failed to auto-connect to machine {machine_id} - connection returned False")
+
+                except Exception as conn_error:
+                    logger.warning(f"✗ Failed to auto-connect to machine {machine_id}: {conn_error}")
+                finally:
+                    loop.close()
+
+            except Exception as e:
+                logger.error(f"Error in connection setup for machine {machine_id}: {e}")
+
+        logger.info(
+            f"Startup auto-connection complete: {connected_count}/{len(machines)} machines connected"
+        )
+
+        # Start the main update thread if any machines connected
+        try:
+            floors_data, machines_data = load_floor_machine_data()
+            if machines_data:
+                app_state.machines_data_cache = machines_data
+                logger.info(
+                    f"Populated machines cache with {len(machines_data.get('machines', []))} machines for auto-reconnection"
+                )
+        except Exception as e:
+            logger.error(f"Error populating machines cache: {e}")
+
+        # Start the main update thread if any machines connected
+        if connected_count > 0:
+            if app_state.update_thread is None or not app_state.update_thread.is_alive():
+                app_state.thread_stop_flag = False
+                app_state.update_thread = Thread(target=opc_update_thread)
+                app_state.update_thread.daemon = True
+                app_state.update_thread.start()
+                logger.info("Started OPC update thread for auto-connected machines")
+        else:
+            logger.info("No machines connected - auto-reconnection thread will handle retry attempts")
+
+    except Exception as e:
+        logger.error(f"Error in startup auto-connection: {e}")
+
+
+def delayed_startup_connect():
+    """Run startup auto-connection after a delay to avoid blocking app startup"""
+    import time
+
+    time.sleep(3)  # Wait 3 seconds for app to fully start
+    startup_auto_connect_machines()
+
+
+def initialize_autoconnect():
+    """Launch the reconnection thread and schedule delayed startup connections."""
+    start_auto_reconnection()
+    startup_thread = Thread(target=delayed_startup_connect)
+    startup_thread.daemon = True
+    startup_thread.start()
+    logger.info("Scheduled startup auto-connection...")
+

--- a/callbacks.py
+++ b/callbacks.py
@@ -1,9 +1,22 @@
 import importlib
+import autoconnect
 
 
 def register_callbacks(app):
     main = importlib.import_module("EnpresorOPCDataViewBeforeRestructureLegacy")
-    globals().update({k:v for k,v in vars(main).items() if k not in globals()})
+    globals().update({k: v for k, v in vars(main).items() if k not in globals()})
+    for name in [
+        "app_state",
+        "machine_connections",
+        "connect_and_monitor_machine",
+        "load_floor_machine_data",
+        "opc_update_thread",
+        "auto_reconnection_thread",
+        "logger",
+    ]:
+        if name in globals():
+            setattr(autoconnect, name, globals()[name])
+    autoconnect.initialize_autoconnect()
     LIVE_LIKE_MODES = {"live", "lab"}
 
     def format_enpresor(text: str):

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,9 +5,29 @@ import dash
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import callbacks
+import autoconnect
 
 
 def test_floor_machine_callback_registered():
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     assert "floor-machine-container.children" in app.callback_map
+
+
+def test_register_callbacks_starts_autoconnect(monkeypatch):
+    started = []
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            self.started = False
+            started.append(self)
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(autoconnect, "Thread", DummyThread)
+
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    assert any(t.started for t in started)


### PR DESCRIPTION
## Summary
- move auto reconnection helpers into new `autoconnect.py`
- wire up autoconnect initialization inside `callbacks.register_callbacks`
- use the shared module from the legacy dashboard
- test that callbacks registration launches the autoconnect thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e7839b88327a93e88db1a89c11f