### PR TITLE
Add Gunicorn deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ The script prints the local and network URLs for accessing the interface. Option
 
 As the code is refactored into modules, the entry point and command-line options will remain consistent so that users experience no change in behavior.
 
+## Running with Gunicorn
+
+For production deployments you can run the Dash application using Gunicorn.
+
+1. Install Gunicorn:
+   ```bash
+   pip install gunicorn
+   ```
+2. Start the server by pointing Gunicorn at the WSGI entry point:
+   ```bash
+   gunicorn --bind 0.0.0.0:8050 wsgi:application
+   ```
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,3 @@
+from EnpresorOPCDataViewBeforeRestructureLegacy import app
+
+application = app.server


### PR DESCRIPTION
## Summary
- add wsgi.py so Gunicorn can serve the Dash app
- document how to run with Gunicorn in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861627764ec8327ae186b74d90eb7bd