### PR TITLE
Add nav safety store

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2704,6 +2704,7 @@ app.layout = html.Div([
 
     # ─── Hidden state stores ───────────────────────────────────────────────
     dcc.Store(id="current-dashboard",       data="new"),
+    dcc.Store(id="dashboard-nav-safety", data={}),
     dcc.Store(id="production-data-store",   data={"capacity": 50000, "accepts": 47500, "rejects": 2500}),
     dcc.Store(id="alarm-data",              data={"alarms": []}),
     dcc.Store(id="metric-logging-store"),

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import importlib
+import pytest
+
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import autoconnect
+
+
+def test_dashboard_nav_safety_store_exists(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    module_name = "EnpresorOPCDataViewBeforeRestructureLegacy"
+    if module_name in sys.modules:
+        mod = importlib.reload(sys.modules[module_name])
+    else:
+        mod = importlib.import_module(module_name)
+    store_ids = [getattr(c, "id", None) for c in mod.app.layout.children]
+    assert "dashboard-nav-safety" in store_ids


### PR DESCRIPTION
## Summary
- add a dedicated `dashboard-nav-safety` store inside the layout
- test for the presence of the store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630356a4c883279e4ee97ead8c7816