### PR TITLE
Fix duplicate dashboard section IDs

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2521,21 +2521,8 @@ def _render_new_dashboard():
         # Main content area
         html.Div(id="floor-machine-container", className="px-4 pt-2 pb-4"),
 
-        # Add ALL section placeholders as hidden elements
-        html.Div([
-            html.Div(id="section-1-1", children=[], style={"display": "none"}),
-            html.Div(id="section-1-2", children=[], style={"display": "none"}),
-            html.Div(id="section-2", children=[], style={"display": "none"}),
-            html.Div(id="section-3-1", children=[], style={"display": "none"}),
-            html.Div(id="section-3-2", children=[], style={"display": "none"}),
-            html.Div(id="section-4", children=[], style={"display": "none"}),
-            html.Div(id="section-5-1", children=[], style={"display": "none"}),
-            html.Div(id="section-5-2", children=[], style={"display": "none"}),
-            html.Div(id="section-6-1", children=[], style={"display": "none"}),
-            html.Div(id="section-6-2", children=[], style={"display": "none"}),
-            html.Div(id="section-7-1", children=[], style={"display": "none"}),
-            html.Div(id="section-7-2", children=[], style={"display": "none"}),
-        ])
+        # Placeholder container for dynamic sections (IDs defined in main dashboard)
+        html.Div([], id="new-dashboard-placeholders", style={"display": "none"})
     ])
 
 


### PR DESCRIPTION
## Summary
- remove placeholder divs with duplicate IDs in `_render_new_dashboard`
- leave a single hidden container for future dynamic sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68644123bf6c8327b27dc43139f521f3