### PR TITLE
Fix language updates for lab and settings UI

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2399,7 +2399,7 @@ settings_modal = dbc.Modal([
                         ], width=8),
                     ], className="mb-3"),
                 ])
-            ], label=tr("display_tab_label", _initial_lang)),
+            ], label=tr("display_tab_label", _initial_lang), id="display-tab"),
             
             # Updated System tab with "Add machine IP" and ADD button
             dbc.Tab([
@@ -2462,7 +2462,7 @@ settings_modal = dbc.Modal([
                     ),
                     html.Div(id="system-settings-save-status", className="text-success mt-2"),
                 ])
-            ], label="System"),
+            ], label=tr("system_tab_label", _initial_lang), id="system-tab"),
 
             dbc.Tab([
                 html.Div([
@@ -2496,7 +2496,7 @@ settings_modal = dbc.Modal([
                     ),
                     html.Div(id="email-settings-save-status", className="text-success mt-2"),
                 ])
-            ], label="Email Setup"),
+            ], label=tr("email_tab_label", _initial_lang), id="email-tab"),
             
             # About tab remains the same
             dbc.Tab([
@@ -2525,7 +2525,7 @@ settings_modal = dbc.Modal([
                         "(281) 276-3700"
                     ], className="mb-1"),
                 ])
-            ], label="About"),
+            ], label=tr("about_tab_label", _initial_lang), id="about-tab"),
         ]),
     ]),
     dbc.ModalFooter([

--- a/callbacks.py
+++ b/callbacks.py
@@ -1344,8 +1344,19 @@ def _register_callbacks_impl(app):
          Output("smtp-username-label", "children"),
          Output("smtp-password-label", "children"),
          Output("smtp-from-label", "children"),
-         Output("save-email-settings", "children"),
-         Output("production-rate-unit-selector", "options")],
+        Output("save-email-settings", "children"),
+        Output("production-rate-unit-selector", "options"),
+        Output("display-tab", "label"),
+        Output("system-tab", "label"),
+        Output("email-tab", "label"),
+        Output("about-tab", "label"),
+        Output("start-test-btn", "children"),
+        Output("stop-test-btn", "children"),
+        Output("lab-test-name", "placeholder"),
+        Output("clear-data-btn", "children"),
+        Output("upload-image", "children"),
+        Output("add-ip-button", "children"),
+        Output("save-system-settings", "children")],
         [Input("language-preference-store", "data")]
     )
     def refresh_text(lang):
@@ -1406,6 +1417,20 @@ def _register_callbacks_impl(app):
                 {"label": tr("objects_per_min", lang), "value": "objects"},
                 {"label": tr("capacity", lang), "value": "capacity"},
             ],
+            tr("display_tab_label", lang),
+            tr("system_tab_label", lang),
+            tr("email_tab_label", lang),
+            tr("about_tab_label", lang),
+            tr("start_test", lang),
+            tr("stop_test", lang),
+            tr("test_lot_name_placeholder", lang),
+            tr("clear_data", lang),
+            html.Div([
+                tr("drag_and_drop", lang),
+                html.A(tr("select_image", lang))
+            ]),
+            tr("add_button", lang),
+            tr("save_system_settings", lang),
         )
 
     @app.callback(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -147,3 +147,16 @@ def test_lab_buttons_callback(monkeypatch):
     # Other mode
     res = func.__wrapped__(False, "live")
     assert res == (True, "secondary", True, "secondary")
+
+
+def test_refresh_text_includes_lab_controls(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    key = next(k for k in app.callback_map if "threshold-modal-header.children" in k)
+    outputs = [out.component_id + "." + out.component_property for out in app.callback_map[key]["output"]]
+
+    assert "start-test-btn.children" in outputs
+    assert "lab-test-name.placeholder" in outputs
+    assert "display-tab.label" in outputs


### PR DESCRIPTION
## Summary
- ensure system settings tabs and lab controls get translated on language change
- test callback outputs include new refresh logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e0788d908327bb48a1dce5bded55