### PR TITLE
Add lab-mode docs for report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ the `--add-data` option. The separator differs by platform:
 With PyInstaller 6 the bundled files are extracted into an `_internal`
 directory next to the executable.
 
+## Generating Reports in Lab Mode
+
+`generate_report.py` builds PDF summaries from the CSV exports. When working
+with lab data pass the `--lab` option so irregular timestamps are used when
+calculating capacities and object totals:
+
+```bash
+python3 generate_report.py <export directory> --lab
+```
+
 ## Running Tests
 
 Install `pytest` along with any runtime dependencies, for example:


### PR DESCRIPTION
## Summary
- document how to run `generate_report.py` with the `--lab` option

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Could not find dash)*
- `pytest -q` *(fails: ModuleNotFoundError for dash and PIL)*

------
https://chatgpt.com/codex/tasks/task_e_686bd7945f608327aa59ef793291bbf8