### PR TITLE
Add lab mode flag to report layouts

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -7,6 +7,7 @@ import datetime
 import pandas as pd
 import df_processor
 import logging
+import argparse
 from datetime import timedelta
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
@@ -853,6 +854,7 @@ def build_report(
             machines=machines,
             include_global=include_global,
             lang=lang,
+            is_lab_mode=is_lab_mode,
         )
     else:
         draw_layout_standard(
@@ -861,6 +863,7 @@ def build_report(
             machines=machines,
             include_global=include_global,
             lang=lang,
+            is_lab_mode=is_lab_mode,
         )
 
 def draw_machine_sections(
@@ -1193,6 +1196,7 @@ def draw_layout_optimized(
     machines=None,
     include_global=True,
     lang="en",
+    is_lab_mode: bool = False,
 ):
     """Optimized version - CONSISTENT SIZING, 2 machines per page"""
     logger.debug("=== DEBUGGING MACHINE DATA ===")
@@ -1231,7 +1235,7 @@ def draw_layout_optimized(
             margin,
             total_w,
             available_height,
-            is_lab_mode=False,
+            is_lab_mode=is_lab_mode,
             lang=lang,
         )
     
@@ -1269,6 +1273,7 @@ def draw_layout_optimized(
                 total_w,
                 fixed_height_per_machine,
                 global_max_firing,
+                is_lab_mode=is_lab_mode,
                 lang=lang,
             )
             # FIXED spacing between machines
@@ -1295,6 +1300,7 @@ def draw_layout_standard(
     machines=None,
     include_global=True,
     lang="en",
+    is_lab_mode: bool = False,
 ):
     """Standard layout - CONSISTENT SIZING with dynamic page breaks"""
     logger.debug("=== DEBUGGING MACHINE DATA ===")
@@ -1334,7 +1340,7 @@ def draw_layout_standard(
             margin,
             total_w,
             available_height,
-            is_lab_mode=False,
+            is_lab_mode=is_lab_mode,
             lang=lang,
         )
     
@@ -1369,7 +1375,7 @@ def draw_layout_standard(
             total_w,
             fixed_machine_height,
             global_max_firing,
-            is_lab_mode=False,
+            is_lab_mode=is_lab_mode,
             lang=lang,
         )
         
@@ -1390,17 +1396,17 @@ def draw_layout_standard(
 
 if __name__=='__main__':
     sd = os.path.dirname(os.path.abspath(__file__))
-    exp_arg = sys.argv[1] if len(sys.argv) > 1 else os.path.join(sd, 'exports')
-    
-    # Generate date-stamped filename automatically
+    parser = argparse.ArgumentParser(description="Generate production report")
+    parser.add_argument("export_dir", nargs="?", default=os.path.join(sd, 'exports'))
+    parser.add_argument("--optimized", action="store_true", help="use optimized layout")
+    parser.add_argument("--lab", action="store_true", help="enable lab mode calculations")
+    args = parser.parse_args()
+
     pdf_path = generate_report_filename(sd)
-    
-    # Check if user wants optimized layout
-    use_optimized = len(sys.argv) > 2 and sys.argv[2] == '--optimized'
-    
-    if use_optimized:
+
+    if args.optimized:
         logger.info("Using optimized layout (2 machines per page)...")
-        draw_layout_optimized(pdf_path, exp_arg, lang="en")
+        draw_layout_optimized(pdf_path, args.export_dir, lang="en", is_lab_mode=args.lab)
     else:
         logger.info("Using standard layout (dynamic page breaks)...")
-        draw_layout_standard(pdf_path, exp_arg, lang="en")
+        draw_layout_standard(pdf_path, args.export_dir, lang="en", is_lab_mode=args.lab)

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -285,25 +285,36 @@ def test_draw_header_uses_internal_assets_font(tmp_path, monkeypatch):
 def test_build_report_passes_options(monkeypatch):
     captured = {}
 
-    def fake_draw(pdf_path, export_dir, machines=None, include_global=True, lang="en"):
-        captured["args"] = (pdf_path, export_dir, machines, include_global, lang)
+    def fake_draw(pdf_path, export_dir, machines=None, include_global=True, lang="en", is_lab_mode=False):
+        captured["args"] = (pdf_path, export_dir, machines, include_global, lang, is_lab_mode)
 
     monkeypatch.setattr(generate_report, "draw_layout_standard", fake_draw)
     generate_report.build_report({}, "out.pdf", export_dir="exp", machines=["1"], include_global=False)
 
-    assert captured["args"] == ("out.pdf", "exp", ["1"], False, "en")
+    assert captured["args"] == ("out.pdf", "exp", ["1"], False, "en", False)
 
 
 def test_build_report_uses_optimized(monkeypatch):
     called = {}
 
-    def fake_draw(pdf_path, export_dir, machines=None, include_global=True, lang="en"):
-        called["optimized"] = True
+    def fake_draw(pdf_path, export_dir, machines=None, include_global=True, lang="en", is_lab_mode=False):
+        called["optimized"] = is_lab_mode
 
     monkeypatch.setattr(generate_report, "draw_layout_optimized", fake_draw)
-    generate_report.build_report({}, "out.pdf", use_optimized=True, export_dir="exp")
+    generate_report.build_report({}, "out.pdf", use_optimized=True, export_dir="exp", is_lab_mode=True)
 
-    assert called.get("optimized")
+    assert called.get("optimized") == True
+
+def test_build_report_passes_lab_mode(monkeypatch):
+    captured = {}
+
+    def fake_draw(pdf_path, export_dir, machines=None, include_global=True, lang="en", is_lab_mode=False):
+        captured["lab"] = is_lab_mode
+
+    monkeypatch.setattr(generate_report, "draw_layout_standard", fake_draw)
+    generate_report.build_report({}, "out.pdf", export_dir="exp", is_lab_mode=True)
+
+    assert captured["lab"] is True
 
 
 def _extract_total(strings, label):


### PR DESCRIPTION
## Summary
- pass new `is_lab_mode` flag through layout helpers
- expose `--lab` option on CLI
- update tests for new parameter

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686bd7909adc83278509366e396d5910