### PR TITLE
Fix pandas indexing for lab mode

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -88,6 +88,10 @@ def calculate_total_capacity_from_csv_rates(csv_rate_entries, log_interval_minut
 
 def _calculate_capacity_lab_mode(timestamps, rates):
     """Calculate capacity totals using actual time intervals for lab mode data."""
+    # Convert to list to avoid pandas negative index issues
+    timestamps = list(timestamps)
+    rates = list(rates)
+
     if len(timestamps) < 2 or len(rates) < 2:
         return {
             "total_capacity_lbs": 0,
@@ -124,7 +128,7 @@ def _calculate_capacity_lab_mode(timestamps, rates):
         last_rate = float(rates[-1])
         if not pd.isna(last_rate):
             valid_rates.append(last_rate)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, IndexError):
         pass
     
     if not valid_rates:
@@ -144,6 +148,10 @@ def _calculate_capacity_lab_mode(timestamps, rates):
 
 def _calculate_objects_lab_mode(timestamps, rates):
     """Calculate object totals using actual time intervals for lab mode data."""
+    # Convert to list to avoid pandas negative index issues
+    timestamps = list(timestamps)
+    rates = list(rates)
+
     if len(timestamps) < 2 or len(rates) < 2:
         return {
             "total_objects": 0,
@@ -180,7 +188,7 @@ def _calculate_objects_lab_mode(timestamps, rates):
         last_rate = float(rates[-1])
         if not pd.isna(last_rate):
             valid_rates.append(last_rate)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, IndexError):
         pass
     
     if not valid_rates:

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -50,6 +50,21 @@ def test_calculate_total_objects_from_csv_rates():
     assert stats["average_rate_obj_per_min"] == 15
 
 
+def test_calculate_objects_lab_mode_series():
+    rates = generate_report.pd.Series([10, 10])
+    timestamps = generate_report.pd.Series([
+        "2020-01-01 00:00:00",
+        "2020-01-01 00:01:30",
+    ])
+    stats = generate_report.calculate_total_objects_from_csv_rates(
+        rates,
+        timestamps=timestamps,
+        is_lab_mode=True,
+    )
+    assert stats["total_objects"] == pytest.approx(15.0)
+    assert stats["max_rate_obj_per_min"] == 10
+
+
 def test_draw_global_summary_totals(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()


### PR DESCRIPTION
## Summary
- fix pandas negative index errors when calculating lab mode metrics
- add regression test for lab mode series handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', dash)*

------
https://chatgpt.com/codex/tasks/task_e_686bd9c21ed083278482671e2c25445e