### PR TITLE
Use microsecond timestamp format

### DIFF
--- a/hourly_data_saving.py
+++ b/hourly_data_saving.py
@@ -92,7 +92,9 @@ def append_metrics(metrics: dict, machine_id: str,
     os.makedirs(machine_dir, exist_ok=True)
     file_path = os.path.join(machine_dir, filename)
 
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    # Use microsecond precision for timestamps so entries can be ordered
+    # correctly even when multiple samples occur within the same second.
+    timestamp = datetime.now().isoformat(timespec="microseconds")
     row = {"timestamp": timestamp}
     row.update(metrics)
     if mode:
@@ -190,7 +192,7 @@ def purge_old_entries(export_dir: str = EXPORT_DIR, machine_id: Optional[str] = 
             row.setdefault(fn, "")
 
         try:
-            ts = datetime.strptime(row["timestamp"], "%Y-%m-%d %H:%M:%S")
+            ts = datetime.fromisoformat(row["timestamp"])
             if ts >= cutoff:
                 filtered.append(row)
         except Exception:
@@ -226,7 +228,7 @@ def load_recent_metrics(export_dir: str = EXPORT_DIR, machine_id: Optional[str] 
         reader = csv.DictReader(f)
         for row in reader:
             try:
-                ts = datetime.strptime(row["timestamp"], "%Y-%m-%d %H:%M:%S")
+                ts = datetime.fromisoformat(row["timestamp"])
             except Exception:
                 continue
 
@@ -286,7 +288,9 @@ def append_control_log(entry: dict, machine_id: str,
     os.makedirs(machine_dir, exist_ok=True)
     file_path = os.path.join(machine_dir, filename)
 
-    timestamp = entry["time"].strftime("%Y-%m-%d %H:%M:%S")
+    # Store timestamps with microsecond precision for consistency with
+    # ``append_metrics``.
+    timestamp = entry["time"].isoformat(timespec="microseconds")
     row = {"timestamp": timestamp}
     for key, value in entry.items():
         if key not in ("time", "display_timestamp"):
@@ -331,7 +335,7 @@ def load_recent_control_log(export_dir: str = EXPORT_DIR, machine_id: Optional[s
         reader = csv.DictReader(f)
         for row in reader:
             try:
-                ts = datetime.strptime(row["timestamp"], "%Y-%m-%d %H:%M:%S")
+                ts = datetime.fromisoformat(row["timestamp"])
             except Exception:
                 continue
             row["timestamp"] = ts

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -53,8 +53,8 @@ def test_calculate_total_objects_from_csv_rates():
 def test_calculate_objects_lab_mode_series():
     rates = generate_report.pd.Series([10, 10])
     timestamps = generate_report.pd.Series([
-        "2020-01-01 00:00:00",
-        "2020-01-01 00:01:30",
+        "2020-01-01T00:00:00.000000",
+        "2020-01-01T00:01:30.000000",
     ])
     stats = generate_report.calculate_total_objects_from_csv_rates(
         rates,
@@ -74,8 +74,8 @@ def test_draw_global_summary_totals(tmp_path, monkeypatch):
     csv = machine_dir / "last_24h_metrics.csv"
     csv.write_text(
         "timestamp,capacity,accepts,rejects,objects_per_min,counter_1\n"
-        "2020-01-01 00:00:00,60,30,30,10,1\n"
-        "2020-01-01 00:01:00,60,30,30,10,1\n"
+        "2020-01-01T00:00:00.000000,60,30,30,10,1\n"
+        "2020-01-01T00:01:00.000000,60,30,30,10,1\n"
     )
 
     layout = {"machines": {"machines": [{"id": 1, "name": "M1"}], "next_machine_id": 2}}
@@ -118,7 +118,7 @@ def test_draw_machine_sections_runtime_line(tmp_path, monkeypatch):
     csv_file = machine_dir / "last_24h_metrics.csv"
     csv_file.write_text(
         "timestamp,accepts,rejects,running,stopped\n"
-        "2020-01-01 00:00:00,1,0,65,5\n"
+        "2020-01-01T00:00:00.000000,1,0,65,5\n"
     )
 
     monkeypatch.setattr(generate_report.renderPDF, "draw", lambda *a, **k: None)
@@ -139,8 +139,8 @@ def test_draw_machine_sections_totals_match_calculation(tmp_path, monkeypatch):
     csv_file.write_text(
 
         "timestamp,accepts,rejects,running,stopped\n"
-        "2020-01-01 00:00:00,30,10,50,10\n"
-        "2020-01-01 00:01:00,30,10,50,10\n"
+        "2020-01-01T00:00:00.000000,30,10,50,10\n"
+        "2020-01-01T00:01:00.000000,30,10,50,10\n"
 
     )
 
@@ -178,8 +178,8 @@ def test_global_summary_totals_sum_machines(tmp_path, monkeypatch):
         csv = mdir / "last_24h_metrics.csv"
         csv.write_text(
             "timestamp,capacity,accepts,rejects\n"
-            "2020-01-01 00:00:00,60,30,10\n"
-            "2020-01-01 00:01:00,60,30,10\n"
+            "2020-01-01T00:00:00.000000,60,30,10\n"
+            "2020-01-01T00:01:00.000000,60,30,10\n"
         )
 
     monkeypatch.setattr(generate_report, "__file__", str(tmp_path / "dummy.py"))
@@ -354,16 +354,16 @@ def test_objects_per_min_totals_match(tmp_path, monkeypatch):
     m1.mkdir()
     (m1 / "last_24h_metrics.csv").write_text(
         "timestamp,objects_per_min\n"
-        "2020-01-01 00:00:00,5\n"
-        "2020-01-01 00:01:00,10\n"
+        "2020-01-01T00:00:00.000000,5\n"
+        "2020-01-01T00:01:00.000000,10\n"
     )
 
     m2 = data_dir / "2"
     m2.mkdir()
     (m2 / "last_24h_metrics.csv").write_text(
         "timestamp,objects_per_min\n"
-        "2020-01-01 00:00:00,2\n"
-        "2020-01-01 00:01:00,3\n"
+        "2020-01-01T00:00:00.000000,2\n"
+        "2020-01-01T00:01:00.000000,3\n"
     )
 
     layout = {
@@ -419,7 +419,7 @@ def test_draw_global_summary_spanish_labels(tmp_path, monkeypatch):
     csv = machine_dir / "last_24h_metrics.csv"
     csv.write_text(
         "timestamp,capacity,accepts,rejects\n"
-        "2020-01-01 00:00:00,60,30,10\n"
+        "2020-01-01T00:00:00.000000,60,30,10\n"
     )
 
     layout = {"machines": {"machines": [{"id": 1}], "next_machine_id": 2}}

--- a/tests/test_purge_old_entries.py
+++ b/tests/test_purge_old_entries.py
@@ -20,7 +20,7 @@ def test_header_rebuild_with_extra_columns(tmp_path):
         writer = csv.DictWriter(f, fieldnames=header)
         writer.writeheader()
         writer.writerow({
-            "timestamp": "2025-06-28 00:00:00",
+            "timestamp": "2025-06-28T00:00:00.000000",
             "capacity": "1",
             "accepts": "0",
             "rejects": "0",


### PR DESCRIPTION
## Summary
- store metrics and control log timestamps with microseconds
- parse timestamps with `datetime.fromisoformat`
- update tests to use the new timestamp precision

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError for PIL and dash)*

------
https://chatgpt.com/codex/tasks/task_e_686be8c37aac8327bb22d4c6b94c3374