### PR TITLE
Adjust report button timeout

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -386,7 +386,7 @@ def _register_callbacks_impl(app):
             return True
         if stop_time is None:
             return False
-        return (time.time() - stop_time) < 20
+        return (time.time() - stop_time) < 30
 
     @app.callback(
         [Output("delete-confirmation-modal", "is_open"),


### PR DESCRIPTION
## Summary
- extend report button disable timeout from 20s to 30s

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686bf4138990832780695016d58751ec