### PR TITLE
Delay lab-test stop

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4739,33 +4739,54 @@ def _register_callbacks_impl(app):
          Output("start-test-btn", "color"),
          Output("stop-test-btn", "disabled"),
          Output("stop-test-btn", "color")],
-        [Input("lab-test-running", "data"), Input("mode-selector", "value")],
+        [Input("lab-test-running", "data"),
+         Input("mode-selector", "value"),
+         Input("status-update-interval", "n_intervals")],
+        [State("lab-test-stop-time", "data")],
     )
-    def toggle_lab_test_buttons(running, mode):
+    def toggle_lab_test_buttons(running, mode, n_intervals, stop_time):
         """Enable/disable lab start/stop buttons based on test state."""
         if mode != "lab":
             return True, "secondary", True, "secondary"
+
+        # Disable both buttons during the 30s grace period after stopping
+        if running and stop_time and (time.time() - stop_time < 30):
+            return True, "secondary", True, "secondary"
+
         if running:
             return True, "secondary", False, "danger"
+
         return False, "success", True, "secondary"
 
     @app.callback(
         Output("lab-test-running", "data"),
-        [Input("start-test-btn", "n_clicks"), Input("stop-test-btn", "n_clicks"), Input("mode-selector", "value")],
-        [State("lab-test-running", "data")],
+        [Input("start-test-btn", "n_clicks"),
+         Input("stop-test-btn", "n_clicks"),
+         Input("mode-selector", "value"),
+         Input("status-update-interval", "n_intervals")],
+        [State("lab-test-running", "data"), State("lab-test-stop-time", "data")],
         prevent_initial_call=True,
     )
-    def update_lab_running(start_click, stop_click, mode, running):
+    def update_lab_running(start_click, stop_click, mode, n_intervals, running, stop_time):
+        """Maintain lab running state for 30 seconds after stopping."""
         ctx = callback_context
+
         if mode != "lab":
             return False
-        if not ctx.triggered:
-            return running
-        trigger = ctx.triggered[0]["prop_id"].split(".")[0]
-        if trigger == "start-test-btn":
-            return True
-        if trigger == "stop-test-btn":
+
+        if ctx.triggered:
+            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+            if trigger == "start-test-btn":
+                return True
+            elif trigger == "stop-test-btn":
+                # stop_time is recorded in a separate callback. Continue
+                # reporting as running until 30 seconds elapse.
+                return running
+
+        # Check if we should end the test based on the stop time
+        if running and stop_time and (time.time() - stop_time >= 30):
             return False
+
         return running
 
     @app.callback(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -137,15 +137,20 @@ def test_lab_buttons_callback(monkeypatch):
     func = app.callback_map[key]["callback"]
 
     # Not running yet
-    res = func.__wrapped__(False, "lab")
+    res = func.__wrapped__(False, "lab", 0, None)
     assert res == (False, "success", True, "secondary")
 
     # Running
-    res = func.__wrapped__(True, "lab")
+    res = func.__wrapped__(True, "lab", 0, None)
     assert res == (True, "secondary", False, "danger")
 
+    # Grace period after stopping
+    monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
+    res = func.__wrapped__(True, "lab", 0, 90.0)
+    assert res == (True, "secondary", True, "secondary")
+
     # Other mode
-    res = func.__wrapped__(False, "live")
+    res = func.__wrapped__(False, "live", 0, None)
     assert res == (True, "secondary", True, "secondary")
 
 


### PR DESCRIPTION
## Summary
- continue collecting lab data for 30s after stopping
- disable lab buttons during stop delay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL' and 'dash')*


------
https://chatgpt.com/codex/tasks/task_e_686bf67ec2648327834ef58fffb9fd28