### PR TITLE
Fix lab filename reset timing

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4788,6 +4788,8 @@ def _register_callbacks_impl(app):
 
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - stop_time >= 30):
+            global current_lab_filename
+            current_lab_filename = None
             return False
 
         return running
@@ -4811,7 +4813,6 @@ def _register_callbacks_impl(app):
             )
             current_lab_filename = filename
             return {"filename": filename}
-        current_lab_filename = None
         return {}
 
     @app.callback(

--- a/tests/test_lab_logging.py
+++ b/tests/test_lab_logging.py
@@ -48,3 +48,38 @@ def test_lab_logging_uses_single_file(monkeypatch):
     log_func.__wrapped__(1, {"connected": True}, {"mode": "lab"}, None, None, {"unit": "lb"}, True, {"machine_id": 1}, {})
 
     assert len(set(captured)) == 1
+
+
+def test_lab_stop_retains_filename(monkeypatch):
+    app = setup_app(monkeypatch)
+    log_func = app.callback_map["metric-logging-store.data"]["callback"]
+    info_func = app.callback_map["lab-test-info.data"]["callback"]
+
+    tags = {
+        CAPACITY_TAG: {"data": callbacks.TagData(CAPACITY_TAG)},
+        OPM_TAG: {"data": callbacks.TagData(OPM_TAG)},
+    }
+    tags[CAPACITY_TAG]["data"].latest_value = 1000
+    tags[OPM_TAG]["data"].latest_value = 100
+
+    callbacks.machine_connections = {1: {"tags": tags, "connected": True}}
+
+    captured = []
+
+    monkeypatch.setattr(
+        callbacks,
+        "append_metrics",
+        lambda metrics, machine_id=None, filename=None, mode=None: captured.append(filename),
+    )
+
+    start_info = info_func.__wrapped__(1, None, "MyStopTest")
+    assert "filename" in start_info
+
+    # simulate pressing stop
+    stop_info = info_func.__wrapped__(None, 1, "")
+    assert stop_info == {}
+
+    # log metrics while the lab test is still considered running
+    log_func.__wrapped__(0, {"connected": True}, {"mode": "lab"}, None, None, {"unit": "lb"}, True, {"machine_id": 1}, stop_info)
+
+    assert captured[-1] == start_info["filename"]


### PR DESCRIPTION
## Summary
- keep current_lab_filename after pressing stop
- clear the filename when lab_running finishes
- test regression for stop click logging

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Could not find a version that satisfies the requirement dash)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686c042d02948327ae639990344aa3a1