### PR TITLE
Fix lab log filename

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5141,7 +5141,7 @@ def _register_callbacks_impl(app):
 
         In lab mode, metrics are logged at every interval.
         """
-        global machine_connections
+        global machine_connections, current_lab_filename
     
         CAPACITY_TAG = "Status.ColorSort.Sort1.Throughput.KgPerHour.Current"
         REJECTS_TAG = "Status.ColorSort.Sort1.Total.Percentage.Current"


### PR DESCRIPTION
## Summary
- ensure `log_current_metrics` updates the global `current_lab_filename`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686c080582dc8327892bc77d8b2ce73f