### PR TITLE
Apply lab object scaling factor

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -22,6 +22,7 @@ import math  # for label angle calculations
 # Default fonts used throughout the report
 FONT_DEFAULT = "Helvetica"
 FONT_BOLD = "Helvetica-Bold"
+LAB_OBJECT_SCALE_FACTOR = 1.042
 
 from i18n import tr
 
@@ -175,9 +176,11 @@ def _calculate_objects_lab_mode(timestamps, rates):
             
             # Calculate actual time interval in minutes
             time_diff_minutes = (next_time - current_time).total_seconds() / 60
-            
-            # Add production for this interval
-            total_objects += current_rate * time_diff_minutes
+
+            # Add production for this interval with scaling factor
+            total_objects += (
+                current_rate * time_diff_minutes * LAB_OBJECT_SCALE_FACTOR
+            )
             valid_rates.append(current_rate)
             
         except (ValueError, TypeError):

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -61,7 +61,8 @@ def test_calculate_objects_lab_mode_series():
         timestamps=timestamps,
         is_lab_mode=True,
     )
-    assert stats["total_objects"] == pytest.approx(15.0)
+    expected_total = 15.0 * generate_report.LAB_OBJECT_SCALE_FACTOR
+    assert stats["total_objects"] == pytest.approx(expected_total)
     assert stats["max_rate_obj_per_min"] == 10
 
 
@@ -352,7 +353,8 @@ def test_global_max_firing_totals_lab_mode(tmp_path):
     max_val = generate_report.calculate_global_max_firing_average(
         str(tmp_path), ["1", "2"], is_lab_mode=True
     )
-    assert max_val == pytest.approx(10.0)
+    scaled_max = 10.0 * generate_report.LAB_OBJECT_SCALE_FACTOR
+    assert max_val == pytest.approx(scaled_max)
 
 
 def _extract_total(strings, label):


### PR DESCRIPTION
## Summary
- add `LAB_OBJECT_SCALE_FACTOR` constant
- apply the factor when computing objects in lab mode
- update tests for new scaling

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError for dash and PIL)*

------
https://chatgpt.com/codex/tasks/task_e_686c1e8272f48327b0bef45e10fcb9f0