### PR TITLE
Add lab mode production data test

### DIFF
--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -35,6 +35,35 @@ def create_log(tmp_path):
     return path
 
 
+def create_lab_metrics(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir(parents=True, exist_ok=True)
+    path = machine_dir / "Lab_Test_sample.csv"
+    fieldnames = [
+        "timestamp",
+        "capacity",
+        "accepts",
+        "rejects",
+        "objects_per_min",
+    ] + [f"counter_{i}" for i in range(1, 13)]
+
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for i in range(3):
+            row = {
+                "timestamp": f"2025-01-01T00:00:0{i}",
+                "capacity": float(10 * (i + 1)),
+                "accepts": float(8 * (i + 1)),
+                "rejects": float(2 * (i + 1)),
+                "objects_per_min": 60,
+            }
+            for j in range(1, 13):
+                row[f"counter_{j}"] = i + 1 if j == 1 else 0
+            writer.writerow(row)
+    return path
+
+
 def test_update_section_5_2_lab_reads_log(monkeypatch, tmp_path):
     app = setup_app(monkeypatch, tmp_path)
     create_log(tmp_path)
@@ -59,3 +88,34 @@ def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
 
     graph = result.children[1]
     assert list(graph.figure.data[0].y) == [1.0, 2.0, 3.0]
+
+
+def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    csv_path = create_lab_metrics(tmp_path)
+    func = app.callback_map["section-1-1.children"]["callback"]
+
+    callbacks.previous_counter_values = [0] * 12
+
+    _, prod = func.__wrapped__(
+        0,
+        "main",
+        {},
+        {},
+        "en",
+        {"connected": False},
+        {"mode": "lab"},
+        {},
+        {"unit": "lb"},
+    )
+
+    with csv_path.open() as f:
+        rows = list(csv.DictReader(f))
+    last = rows[-1]
+    expected = {
+        "capacity": float(last["capacity"]),
+        "accepts": float(last["accepts"]),
+        "rejects": float(last["rejects"]),
+    }
+
+    assert prod == expected


### PR DESCRIPTION
## Summary
- extend lab chart utilities to create a metrics file with capacity
- test that section 1‑1 reads lab metrics correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686c744c9b9483279f95630bdd9f4c81