### PR TITLE
Support lab metrics in capacity view

### DIFF
--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -1,0 +1,60 @@
+import os
+import csv
+import dash
+
+import callbacks
+import autoconnect
+
+
+def setup_app(monkeypatch, tmp_path):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    monkeypatch.setattr(callbacks.hourly_data_saving, "EXPORT_DIR", str(tmp_path))
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    return app
+
+
+def create_log(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir(parents=True, exist_ok=True)
+    path = machine_dir / "Lab_Test_sample.csv"
+    fieldnames = [
+        "timestamp",
+        "capacity",
+        "accepts",
+        "rejects",
+        "objects_per_min",
+        "running",
+        "stopped",
+    ] + [f"counter_{i}" for i in range(1, 13)] + ["mode"]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        row = {
+            "timestamp": "2025-01-01T00:00:00",
+            "capacity": "100",
+            "accepts": "80",
+            "rejects": "20",
+            "objects_per_min": "60",
+            "running": "1",
+            "stopped": "0",
+            "mode": "Lab",
+        }
+        for i in range(1, 13):
+            row[f"counter_{i}"] = "0"
+        writer.writerow(row)
+    return path
+
+
+def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    create_log(tmp_path)
+    callbacks.active_machine_id = 1
+    key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
+    func = app.callback_map[key]["callback"]
+
+    _, prod = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {}, {"unit": "lb"})
+
+    assert prod["capacity"] == 100
+    assert prod["accepts"] == 80
+    assert prod["rejects"] == 20


### PR DESCRIPTION
## Summary
- add helper `load_last_lab_metrics` to read the last row of a lab log
- show latest lab metrics when in lab mode and not connected
- test lab metrics display

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Could not find a version that satisfies the requirement dash)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686c744afe7c832798e35ccaed17afca