### PR TITLE
Fix lab mode trend graph

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -119,6 +119,39 @@ def load_lab_totals(machine_id, filename=None):
     return counter_totals, timestamps, object_totals
 
 
+def load_lab_object_rates(machine_id):
+    """Return timestamped objects-per-minute values from a lab log."""
+    machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
+    files = glob.glob(os.path.join(machine_dir, "Lab_Test_*.csv"))
+    if not files:
+        return [], []
+
+    path = max(files, key=os.path.getmtime)
+    if not os.path.exists(path):
+        return [], []
+
+    times = []
+    opm_values = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ts = row.get("timestamp")
+            if ts:
+                try:
+                    ts_val = datetime.fromisoformat(ts)
+                except Exception:
+                    ts_val = ts
+                times.append(ts_val)
+
+            opm = row.get("objects_per_min")
+            try:
+                opm_values.append(float(opm) if opm else 0.0)
+            except ValueError:
+                opm_values.append(0.0)
+
+    return times, opm_values
+
+
 def load_last_lab_metrics(machine_id):
     """Return the last capacity/accepts/rejects values from a lab log."""
     machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
@@ -3784,9 +3817,9 @@ def _register_callbacks_impl(app):
                 max_val = 10000
         elif mode == "lab":
             mid = active_machine_data.get("machine_id") if active_machine_data else None
-            _, times, totals = load_lab_totals(mid)
+            times, opm_values = load_lab_object_rates(mid)
             x_data = [t.strftime("%H:%M:%S") if isinstance(t, datetime) else t for t in times]
-            y_data = totals
+            y_data = opm_values
             if y_data:
                 min_val = max(0, min(y_data) * 0.9)
                 max_val = max(y_data) * 1.1

--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -87,7 +87,7 @@ def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
     result = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {"machine_id": 1}, {"unit": "lb"}, "objects")
 
     graph = result.children[1]
-    assert list(graph.figure.data[0].y) == [1.0, 2.0, 3.0]
+    assert list(graph.figure.data[0].y) == [60.0, 60.0, 60.0]
 
 
 def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- correct section 5-1 lab mode to display objects per minute instead of cumulative totals
- add helper to read objects-per-minute values from lab logs
- update tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686d0d3adbc48327890e268e9cce65c9