### PR TITLE
Update lab mode reject display

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2414,8 +2414,9 @@ def _register_callbacks_impl(app):
             if accepts_count_fmt is not None
             else f"{accepts_formatted} {capacity_unit_label(weight_pref, False)} "
         )
+        rej_label = "obj" if mode == "lab" else "pcs"
         rej_display = (
-            f"{reject_count_fmt} pcs / {rejects_formatted} {capacity_unit_label(weight_pref, False)} "
+            f"{reject_count_fmt} {rej_label} / {rejects_formatted} {capacity_unit_label(weight_pref, False)} "
             if reject_count_fmt is not None
             else f"{rejects_formatted} {capacity_unit_label(weight_pref, False)} "
         )

--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -133,4 +133,4 @@ def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
 
     assert cap_text == f"{capacity_count:,.0f} pcs / {expected['capacity']:,.0f} {unit_label}"
     assert acc_text == f"{accepts_count:,.0f} pcs / {expected['accepts']:,.0f} {unit_label_plain} "
-    assert rej_text == f"{reject_count:,.0f} pcs / {expected['rejects']:,.0f} {unit_label_plain} "
+    assert rej_text == f"{reject_count:,.0f} obj / {expected['rejects']:,.0f} {unit_label_plain} "

--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -80,4 +80,4 @@ def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
 
     assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.0f} {unit_label}"
     assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.0f} {unit_label_plain} "
-    assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.0f} {unit_label_plain} "
+    assert rej_text == f"{reject_count:,.0f} obj / {expected_rej:,.0f} {unit_label_plain} "


### PR DESCRIPTION
## Summary
- show rejects as object counts when running in lab mode
- update lab metrics tests

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d5157f883279ab3d7836f26e937