### PR TITLE
Fix lab totals integration

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -72,7 +72,13 @@ _REGISTERING = False
 
 
 def load_lab_totals(machine_id, filename=None):
-    """Return cumulative counter totals and object totals from a lab log."""
+    """Return cumulative counter totals and object totals from a lab log.
+
+    The counters in lab logs represent objects/min rates rather than raw
+    counts. To get accurate totals we integrate these rates over the actual
+    time intervals between log entries. This mirrors the logic used when
+    generating the PDF report so the dashboard matches the report output.
+    """
     machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
     if filename:
         path = os.path.join(machine_dir, filename)
@@ -92,6 +98,7 @@ def load_lab_totals(machine_id, filename=None):
 
     with open(path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
+        prev_ts = None
         for row in reader:
             ts = row.get("timestamp")
             if ts:
@@ -100,18 +107,29 @@ def load_lab_totals(machine_id, filename=None):
                 except Exception:
                     ts_val = ts
                 timestamps.append(ts_val)
+            else:
+                ts_val = None
+
+            # Determine elapsed minutes since last row for integration
+            if prev_ts is not None and ts_val is not None:
+                diff_min = (ts_val - prev_ts).total_seconds() / 60.0
+            else:
+                diff_min = 0.0
+            prev_ts = ts_val if ts_val is not None else prev_ts
 
             for i in range(1, 13):
                 val = row.get(f"counter_{i}")
                 try:
-                    counter_totals[i - 1] += float(val) if val else 0.0
+                    rate = float(val) if val else 0.0
                 except ValueError:
-                    pass
+                    rate = 0.0
+                counter_totals[i - 1] += rate * diff_min * generate_report.LAB_OBJECT_SCALE_FACTOR
 
             opm = row.get("objects_per_min")
             if opm:
                 try:
-                    obj_sum += float(opm) / 60.0
+                    obj_rate = float(opm)
+                    obj_sum += obj_rate * diff_min * generate_report.LAB_OBJECT_SCALE_FACTOR
                 except ValueError:
                     pass
             object_totals.append(obj_sum)

--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import callbacks
 import autoconnect
+import generate_report
 
 
 def setup_app(monkeypatch, tmp_path):
@@ -74,9 +75,10 @@ def test_update_section_5_2_lab_reads_log(monkeypatch, tmp_path):
 
     res = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {"machine_id": 1})
 
-    assert callbacks.previous_counter_values[0] == 3
+    expected_total = 2 * generate_report.LAB_OBJECT_SCALE_FACTOR / 60
+    assert pytest.approx(callbacks.previous_counter_values[0], rel=1e-3) == expected_total
     bar = res.children[1]
-    assert bar.figure.data[0].y[0] == 3
+    assert pytest.approx(bar.figure.data[0].y[0], rel=1e-3) == expected_total
 
 
 def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
@@ -125,7 +127,7 @@ def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
     unit_label = callbacks.capacity_unit_label({"unit": "lb"})
     unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)
 
-    assert prod == expected
+    assert prod == pytest.approx(expected)
 
     cap_text = content.children[1].children[2].children
     acc_text = content.children[2].children[2].children


### PR DESCRIPTION
## Summary
- integrate lab counter rates over time in `load_lab_totals`
- adjust lab chart tests for new calculation logic

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686d2513eae0832792128ead9c62bc41