### PR TITLE
Fix decimal formatting in production display

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2356,8 +2356,8 @@ def _register_callbacks_impl(app):
         # Format values with commas for thousands separator and limited decimal places
         if total_capacity_formatted is None:
             total_capacity_formatted = f"{total_capacity:,.0f}"
-        accepts_formatted = f"{accepts:,.0f}"
-        rejects_formatted = f"{rejects:,.0f}"
+        accepts_formatted = f"{accepts:,.2f}"
+        rejects_formatted = f"{rejects:,.2f}"
         accepts_percent_formatted = f"{accepts_percent:.1f}"
         rejects_percent_formatted = f"{rejects_percent:.1f}"
 

--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -131,6 +131,6 @@ def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
     acc_text = content.children[2].children[2].children
     rej_text = content.children[3].children[2].children
 
-    assert cap_text == f"{capacity_count:,.0f} pcs / {expected['capacity']:,.0f} {unit_label}"
-    assert acc_text == f"{accepts_count:,.0f} pcs / {expected['accepts']:,.0f} {unit_label_plain} "
-    assert rej_text == f"{reject_count:,.0f} pcs / {expected['rejects']:,.0f} {unit_label_plain} "
+    assert cap_text == f"{capacity_count:,.0f} pcs / {expected['capacity']:,.2f} {unit_label}"
+    assert acc_text == f"{accepts_count:,.0f} pcs / {expected['accepts']:,.2f} {unit_label_plain} "
+    assert rej_text == f"{reject_count:,.0f} pcs / {expected['rejects']:,.2f} {unit_label_plain} "

--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -78,6 +78,6 @@ def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
     acc_text = content.children[2].children[2].children
     rej_text = content.children[3].children[2].children
 
-    assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.0f} {unit_label}"
-    assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.0f} {unit_label_plain} "
-    assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.0f} {unit_label_plain} "
+    assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.2f} {unit_label}"
+    assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.2f} {unit_label_plain} "
+    assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.2f} {unit_label_plain} "


### PR DESCRIPTION
## Summary
- format accepts/rejects with two decimals in callbacks
- update lab chart/metrics tests for new display format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PIL and dash)*

------
https://chatgpt.com/codex/tasks/task_e_686d37aca7bc83278337420194135afc