### PR TITLE
Fix lab totals timing

### DIFF
--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import csv
+import generate_report
 import pytest
 
 dash = pytest.importorskip("dash")
@@ -87,7 +88,12 @@ def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
     result = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {"machine_id": 1}, {"unit": "lb"}, "objects")
 
     graph = result.children[1]
-    assert list(graph.figure.data[0].y) == [1.0, 2.0, 3.0]
+    expected = [
+        0.0,
+        1 * generate_report.LAB_OBJECT_SCALE_FACTOR,
+        2 * generate_report.LAB_OBJECT_SCALE_FACTOR,
+    ]
+    assert list(graph.figure.data[0].y) == pytest.approx(expected)
 
 
 def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- adjust lab totals calculation to use real time deltas and scaling
- import generate_report in lab chart tests
- update lab chart expectations for scaled totals

## Testing
- `pip install -r requirements.txt -r test-requirements.txt` *(fails: Could not find a version that satisfies the requirement dash)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_686d37a832ac832788cd0bcb6b300d88