### PR TITLE
Ensure zeroed capacity in lab mode

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2336,10 +2336,18 @@ def _register_callbacks_impl(app):
                     "rejects": rejects,
                 }
             else:
-                total_capacity = production_data.get("capacity", 50000)
-                accepts = production_data.get("accepts", 47500)
-                rejects = production_data.get("rejects", 2500)
+                # No existing lab log yet. Use zeroed placeholders for
+                # all metrics so the dashboard doesn't display stale live
+                # production values when switching to lab mode.
+                total_capacity = 0
+                accepts = 0
+                rejects = 0
                 capacity_count = accepts_count = reject_count = 0
+                production_data = {
+                    "capacity": 0,
+                    "accepts": 0,
+                    "rejects": 0,
+                }
 
         elif mode == "demo":
     

--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -81,3 +81,34 @@ def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
     assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.2f} {unit_label}"
     assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.2f} {unit_label_plain} "
     assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.2f} {unit_label_plain} "
+
+
+def test_update_section_1_1_lab_no_log(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    callbacks.active_machine_id = 1
+    key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
+    func = app.callback_map[key]["callback"]
+
+    content, prod = func.__wrapped__(
+        0,
+        "main",
+        {},
+        {},
+        "en",
+        {"connected": False},
+        {"mode": "lab"},
+        {},
+        {"unit": "lb"},
+    )
+
+    unit_label = callbacks.capacity_unit_label({"unit": "lb"})
+    unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)
+
+    cap_text = content.children[1].children[2].children
+    acc_text = content.children[2].children[2].children
+    rej_text = content.children[3].children[2].children
+
+    assert prod == {"capacity": 0, "accepts": 0, "rejects": 0}
+    assert cap_text == f"0 pcs / 0 {unit_label}"
+    assert acc_text == f"0 pcs / 0.00 {unit_label_plain} "
+    assert rej_text == f"0 pcs / 0.00 {unit_label_plain} "


### PR DESCRIPTION
## Summary
- display zeroed metrics when no lab log is present
- test that lab mode shows placeholder values with no log

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686d3ab5e738832799f1ff1fd31d9b6e