### PR TITLE
Update lab metrics with connected checks

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2248,7 +2248,7 @@ def _register_callbacks_impl(app):
         # Only update values if:
         # 1. We're in demo mode (always update with new random values)
         # 2. We're in live mode and connected (update from tags)
-        if mode in LIVE_LIKE_MODES and app_state_data.get("connected", False):
+        if mode == "live" and app_state_data.get("connected", False):
             # Live mode: get values from OPC UA tags
             total_capacity = 0
     

--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -99,7 +99,10 @@ def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
 def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
     app = setup_app(monkeypatch, tmp_path)
     csv_path = create_lab_metrics(tmp_path)
-    func = app.callback_map["section-1-1.children"]["callback"]
+    key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
+    func = app.callback_map[key]["callback"]
+
+    callbacks.active_machine_id = 1
 
     callbacks.previous_counter_values = [0] * 12
 
@@ -137,6 +140,6 @@ def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
     acc_text = content.children[2].children[2].children
     rej_text = content.children[3].children[2].children
 
-    assert cap_text == f"{capacity_count:,.0f} pcs / {expected['capacity']:,.2f} {unit_label}"
+    assert cap_text == f"{capacity_count:,.0f} pcs / {expected['capacity']:,.0f} {unit_label}"
     assert acc_text == f"{accepts_count:,.0f} pcs / {expected['accepts']:,.2f} {unit_label_plain} "
     assert rej_text == f"{reject_count:,.0f} pcs / {expected['rejects']:,.2f} {unit_label_plain} "

--- a/tests/test_lab_logging.py
+++ b/tests/test_lab_logging.py
@@ -41,6 +41,11 @@ def test_lab_logging_uses_single_file(monkeypatch):
 
     monkeypatch.setattr(callbacks, "append_metrics", fake_append)
 
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("start-test-btn"))
     info = start_func.__wrapped__(1, None, "MyTest")
     assert "filename" in info
 
@@ -72,10 +77,16 @@ def test_lab_stop_retains_filename(monkeypatch):
         lambda metrics, machine_id=None, filename=None, mode=None: captured.append(filename),
     )
 
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("start-test-btn"))
     start_info = info_func.__wrapped__(1, None, "MyStopTest")
     assert "filename" in start_info
 
     # simulate pressing stop
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("stop-test-btn"))
     stop_info = info_func.__wrapped__(None, 1, "")
     assert stop_info == {}
 

--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -78,7 +78,7 @@ def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
     acc_text = content.children[2].children[2].children
     rej_text = content.children[3].children[2].children
 
-    assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.2f} {unit_label}"
+    assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.0f} {unit_label}"
     assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.2f} {unit_label_plain} "
     assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.2f} {unit_label_plain} "
 
@@ -96,6 +96,74 @@ def test_update_section_1_1_lab_no_log(monkeypatch, tmp_path):
         {},
         "en",
         {"connected": False},
+        {"mode": "lab"},
+        {},
+        {"unit": "lb"},
+    )
+
+    unit_label = callbacks.capacity_unit_label({"unit": "lb"})
+    unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)
+
+    cap_text = content.children[1].children[2].children
+    acc_text = content.children[2].children[2].children
+    rej_text = content.children[3].children[2].children
+
+    assert prod == {"capacity": 0, "accepts": 0, "rejects": 0}
+    assert cap_text == f"0 pcs / 0 {unit_label}"
+    assert acc_text == f"0 pcs / 0.00 {unit_label_plain} "
+    assert rej_text == f"0 pcs / 0.00 {unit_label_plain} "
+
+
+def test_update_section_1_1_lab_reads_log_connected(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    create_log(tmp_path)
+    callbacks.active_machine_id = 1
+    key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
+    func = app.callback_map[key]["callback"]
+
+    content, prod = func.__wrapped__(0, "main", {}, {}, "en", {"connected": True}, {"mode": "lab"}, {}, {"unit": "lb"})
+
+    metrics = callbacks.load_lab_totals_metrics(1)
+    total_lbs, acc_lbs, rej_lbs, _ = metrics
+
+    expected_cap = callbacks.convert_capacity_from_lbs(total_lbs, {"unit": "lb"})
+    expected_acc = callbacks.convert_capacity_from_lbs(acc_lbs, {"unit": "lb"})
+    expected_rej = callbacks.convert_capacity_from_lbs(rej_lbs, {"unit": "lb"})
+
+    assert prod["capacity"] == expected_cap
+    assert prod["accepts"] == expected_acc
+    assert prod["rejects"] == expected_rej
+
+    counter_totals, _, object_totals = callbacks.load_lab_totals(1)
+    reject_count = sum(counter_totals)
+    capacity_count = object_totals[-1]
+    accepts_count = max(0, capacity_count - reject_count)
+
+    unit_label = callbacks.capacity_unit_label({"unit": "lb"})
+    unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)
+
+    cap_text = content.children[1].children[2].children
+    acc_text = content.children[2].children[2].children
+    rej_text = content.children[3].children[2].children
+
+    assert cap_text == f"{capacity_count:,.0f} pcs / {expected_cap:,.0f} {unit_label}"
+    assert acc_text == f"{accepts_count:,.0f} pcs / {expected_acc:,.2f} {unit_label_plain} "
+    assert rej_text == f"{reject_count:,.0f} pcs / {expected_rej:,.2f} {unit_label_plain} "
+
+
+def test_update_section_1_1_lab_no_log_connected(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    callbacks.active_machine_id = 1
+    key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
+    func = app.callback_map[key]["callback"]
+
+    content, prod = func.__wrapped__(
+        0,
+        "main",
+        {},
+        {},
+        "en",
+        {"connected": True},
         {"mode": "lab"},
         {},
         {"unit": "lb"},


### PR DESCRIPTION
## Summary
- only fetch live production data when mode is `live`
- ensure lab object counts are shown even when connected
- expand lab metric tests for connected scenarios
- make tests robust to Dash 3 callback map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3d95079c8327b77c503a24a35443