### PR TITLE
Use time-weighted lab counters

### DIFF
--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -67,7 +67,7 @@ def create_lab_metrics(tmp_path):
 
 def test_update_section_5_2_lab_reads_log(monkeypatch, tmp_path):
     app = setup_app(monkeypatch, tmp_path)
-    create_log(tmp_path)
+    csv_path = create_log(tmp_path)
     func = app.callback_map["section-5-2.children"]["callback"]
 
     callbacks.previous_counter_values = [0] * 12
@@ -75,9 +75,15 @@ def test_update_section_5_2_lab_reads_log(monkeypatch, tmp_path):
 
     res = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {"machine_id": 1})
 
-    assert callbacks.previous_counter_values[0] == 3
+    df = generate_report.pd.read_csv(csv_path)
+    stats = generate_report.calculate_total_objects_from_csv_rates(
+        df["counter_1"], timestamps=df["timestamp"], is_lab_mode=True
+    )
+    expected_val = stats["total_objects"]
+
+    assert callbacks.previous_counter_values[0] == pytest.approx(expected_val)
     bar = res.children[1]
-    assert bar.figure.data[0].y[0] == 3
+    assert bar.figure.data[0].y[0] == pytest.approx(expected_val)
 
 
 def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):
@@ -130,6 +136,18 @@ def test_update_section_1_1_lab_uses_log(monkeypatch, tmp_path):
     reject_count = sum(counter_totals)
     capacity_count = object_totals[-1]
     accepts_count = max(0, capacity_count - reject_count)
+
+    df = generate_report.pd.read_csv(csv_path)
+    removed_total = 0
+    for i in range(1, 13):
+        col = f"counter_{i}"
+        if col in df.columns:
+            stats = generate_report.calculate_total_objects_from_csv_rates(
+                df[col], timestamps=df["timestamp"], is_lab_mode=True
+            )
+            removed_total += stats["total_objects"]
+
+    assert reject_count == pytest.approx(removed_total)
 
     unit_label = callbacks.capacity_unit_label({"unit": "lb"})
     unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)

--- a/tests/test_lab_metrics.py
+++ b/tests/test_lab_metrics.py
@@ -4,6 +4,8 @@ import dash
 
 import callbacks
 import autoconnect
+import generate_report
+import pytest
 
 
 def setup_app(monkeypatch, tmp_path):
@@ -48,7 +50,7 @@ def create_log(tmp_path):
 
 def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
     app = setup_app(monkeypatch, tmp_path)
-    create_log(tmp_path)
+    csv_path = create_log(tmp_path)
     callbacks.active_machine_id = 1
     key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
     func = app.callback_map[key]["callback"]
@@ -70,6 +72,18 @@ def test_update_section_1_1_lab_reads_log(monkeypatch, tmp_path):
     reject_count = sum(counter_totals)
     capacity_count = object_totals[-1]
     accepts_count = max(0, capacity_count - reject_count)
+
+    df = generate_report.pd.read_csv(csv_path)
+    removed_total = 0
+    for i in range(1, 13):
+        col = f"counter_{i}"
+        if col in df.columns:
+            stats = generate_report.calculate_total_objects_from_csv_rates(
+                df[col], timestamps=df["timestamp"], is_lab_mode=True
+            )
+            removed_total += stats["total_objects"]
+
+    assert reject_count == pytest.approx(removed_total)
 
     unit_label = callbacks.capacity_unit_label({"unit": "lb"})
     unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)
@@ -116,7 +130,7 @@ def test_update_section_1_1_lab_no_log(monkeypatch, tmp_path):
 
 def test_update_section_1_1_lab_reads_log_connected(monkeypatch, tmp_path):
     app = setup_app(monkeypatch, tmp_path)
-    create_log(tmp_path)
+    csv_path = create_log(tmp_path)
     callbacks.active_machine_id = 1
     key = next(k for k in app.callback_map if k.startswith("..section-1-1.children"))
     func = app.callback_map[key]["callback"]
@@ -138,6 +152,18 @@ def test_update_section_1_1_lab_reads_log_connected(monkeypatch, tmp_path):
     reject_count = sum(counter_totals)
     capacity_count = object_totals[-1]
     accepts_count = max(0, capacity_count - reject_count)
+
+    df = generate_report.pd.read_csv(csv_path)
+    removed_total = 0
+    for i in range(1, 13):
+        col = f"counter_{i}"
+        if col in df.columns:
+            stats = generate_report.calculate_total_objects_from_csv_rates(
+                df[col], timestamps=df["timestamp"], is_lab_mode=True
+            )
+            removed_total += stats["total_objects"]
+
+    assert reject_count == pytest.approx(removed_total)
 
     unit_label = callbacks.capacity_unit_label({"unit": "lb"})
     unit_label_plain = callbacks.capacity_unit_label({"unit": "lb"}, False)


### PR DESCRIPTION
## Summary
- compute lab counter totals using time-weighted object calculations
- verify rejects counters against generate_report in tests
- adjust expected lab values for updated counter logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d43c468048327a803b32e3a004ff8