### PR TITLE
Add test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ the application:
 
 ## Setup
 1. Ensure you have Python 3 installed.
-2. Install required dependencies:
+2. Install required dependencies (include `test-requirements.txt` if you plan to run the test suite):
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r test-requirements.txt
    ```
    (If no `requirements.txt` is provided, install packages referenced in the legacy script as needed.)
 
@@ -120,6 +120,10 @@ Install `pytest` along with any runtime dependencies, for example:
 
 ```bash
 pip install -r requirements.txt -r test-requirements.txt
+```
+or run the helper script:
+```bash
+./scripts/setup-tests.sh
 ```
 
 Then run the test suite from the repository root:

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# Install runtime and test dependencies for running the test suite
+pip install -r requirements.txt -r test-requirements.txt


### PR DESCRIPTION
## Summary
- clarify how to install requirements in the README
- mention setup script for installing test requirements
- add `scripts/setup-tests.sh`

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4a5cb9c48327958d6f3b7b211f3d