### PR TITLE
Improve lab totals caching logic

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -102,11 +102,12 @@ def load_lab_totals(machine_id, filename=None):
     size = stat.st_size
 
     cache = _lab_totals_cache.get(key)
-    if (
-        cache is None
-        or cache.get("mtime") != mtime
-        or size < cache.get("size", 0)
-    ):
+    if cache is not None:
+        # Reset if file was truncated or replaced with an older version
+        if size < cache.get("size", 0) or mtime < cache.get("mtime", 0):
+            cache = None
+
+    if cache is None:
         counter_totals = [0] * 12
         timestamps = []
         object_totals = []

--- a/tests/test_lab_totals_cache.py
+++ b/tests/test_lab_totals_cache.py
@@ -1,0 +1,69 @@
+import csv
+import time
+
+import callbacks
+
+FIELDS = ["timestamp", "objects_per_min"] + [f"counter_{i}" for i in range(1, 13)]
+
+
+def create_log(tmp_path, rows=1):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir(parents=True, exist_ok=True)
+    path = machine_dir / "Lab_Test_sample.csv"
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writeheader()
+        for i in range(rows):
+            row = {"timestamp": f"2025-01-01T00:00:0{i}", "objects_per_min": "60"}
+            for j in range(1, 13):
+                row[f"counter_{j}"] = "1" if j == 1 else "0"
+            writer.writerow(row)
+    return path
+
+
+def append_row(path, idx=0):
+    with path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        row = {"timestamp": f"2025-01-01T00:00:{idx}", "objects_per_min": "60"}
+        for j in range(1, 13):
+            row[f"counter_{j}"] = "1" if j == 1 else "0"
+        writer.writerow(row)
+
+
+def test_append_uses_cached_totals(monkeypatch, tmp_path):
+    monkeypatch.setattr(callbacks.hourly_data_saving, "EXPORT_DIR", str(tmp_path))
+    callbacks._lab_totals_cache.clear()
+    path = create_log(tmp_path, 1)
+
+    ct1, ts1, obj1 = callbacks.load_lab_totals(1)
+    id_ct = id(ct1)
+    id_ts = id(ts1)
+    id_obj = id(obj1)
+
+    time.sleep(1)
+    append_row(path, 1)
+
+    ct2, ts2, obj2 = callbacks.load_lab_totals(1)
+
+    assert id(ct2) == id_ct
+    assert id(ts2) == id_ts
+    assert id(obj2) == id_obj
+    assert ct2[0] == 2
+
+
+def test_truncate_resets_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(callbacks.hourly_data_saving, "EXPORT_DIR", str(tmp_path))
+    callbacks._lab_totals_cache.clear()
+    path = create_log(tmp_path, 2)
+
+    ct1, ts1, obj1 = callbacks.load_lab_totals(1)
+    id_ct1 = id(ct1)
+
+    # rewrite file with only one row (smaller size)
+    path.unlink()
+    create_log(tmp_path, 1)
+
+    ct2, ts2, obj2 = callbacks.load_lab_totals(1)
+
+    assert id(ct2) != id_ct1
+    assert ct2[0] == 1


### PR DESCRIPTION
## Summary
- handle file growth or truncation when caching lab totals
- ensure cached lists persist when appending rows
- reset cache on truncation
- add tests for lab totals cache behavior

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d525bcbc8832799f7b19dd831e7ea