### PR TITLE
Use rate-based totals in lab mode counters

### DIFF
--- a/tests/test_lab_charts.py
+++ b/tests/test_lab_charts.py
@@ -75,9 +75,12 @@ def test_update_section_5_2_lab_reads_log(monkeypatch, tmp_path):
 
     res = func.__wrapped__(0, "main", {}, {}, "en", {"connected": False}, {"mode": "lab"}, {"machine_id": 1})
 
-    assert callbacks.previous_counter_values[0] == 3
+    counter_totals, _, _ = callbacks.load_lab_totals(1)
+    expected = counter_totals[0]
+
+    assert callbacks.previous_counter_values[0] == pytest.approx(expected)
     bar = res.children[1]
-    assert bar.figure.data[0].y[0] == 3
+    assert bar.figure.data[0].y[0] == pytest.approx(expected)
 
 
 def test_update_section_5_1_lab_reads_log(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- compute lab counter totals using time-weighted rates
- update lab chart tests for new counter totals

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d44d13cf48327bbce3216a28d4c7d