### PR TITLE
Add live CSV counter totals and caching

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -20,6 +20,7 @@ import hourly_data_saving
 import autoconnect
 import image_manager as img_utils
 import generate_report
+import df_processor
 try:
     import resource
 except ImportError:  # pragma: no cover - resource not available on Windows
@@ -76,6 +77,9 @@ _REGISTERING = False
 # log file.
 _lab_totals_cache = {}
 
+# Cache of production metrics used in lab mode calculations
+_lab_production_cache = {}
+
 
 def load_lab_totals(machine_id, filename=None):
     """Return cumulative counter totals and object totals from a lab log.
@@ -114,6 +118,7 @@ def load_lab_totals(machine_id, filename=None):
         obj_sum = 0.0
         prev_ts = None
         prev_rate = None
+        prev_counter_rates = [None] * 12
         last_index = -1
     else:
         counter_totals = cache["counter_totals"]
@@ -122,6 +127,7 @@ def load_lab_totals(machine_id, filename=None):
         obj_sum = object_totals[-1] if object_totals else 0.0
         prev_ts = cache.get("prev_ts")
         prev_rate = cache.get("prev_rate")
+        prev_counter_rates = cache.get("prev_counter_rates", [None] * 12)
         last_index = cache.get("last_index", -1)
 
     with open(path, newline="", encoding="utf-8") as f:
@@ -139,12 +145,28 @@ def load_lab_totals(machine_id, filename=None):
                     ts_val = ts
             timestamps.append(ts_val)
 
+            counter_rates = []
             for i in range(1, 13):
                 val = row.get(f"counter_{i}")
                 try:
-                    counter_totals[i - 1] += float(val) if val else 0.0
+                    rate = float(val) if val else None
                 except ValueError:
-                    pass
+                    rate = None
+
+                if (
+                    prev_ts is not None
+                    and isinstance(prev_ts, datetime)
+                    and isinstance(ts_val, datetime)
+                    and prev_counter_rates[i - 1] is not None
+                ):
+                    c_stats = generate_report.calculate_total_objects_from_csv_rates(
+                        [prev_counter_rates[i - 1], prev_counter_rates[i - 1]],
+                        timestamps=[prev_ts, ts_val],
+                        is_lab_mode=True,
+                    )
+                    counter_totals[i - 1] += c_stats.get("total_objects", 0)
+
+                counter_rates.append(rate)
 
             opm = row.get("objects_per_min")
             try:
@@ -168,6 +190,7 @@ def load_lab_totals(machine_id, filename=None):
             object_totals.append(obj_sum)
             prev_ts = ts_val
             prev_rate = rate_val
+            prev_counter_rates = counter_rates
             last_index = idx
 
     _lab_totals_cache[key] = {
@@ -177,6 +200,7 @@ def load_lab_totals(machine_id, filename=None):
         "last_index": last_index,
         "prev_ts": prev_ts,
         "prev_rate": prev_rate,
+        "prev_counter_rates": prev_counter_rates,
         "mtime": mtime,
         "size": size,
     }
@@ -322,6 +346,28 @@ def load_lab_totals_metrics(machine_id):
             elapsed_seconds = 0
 
     return total_capacity, accepts_total, rejects_total, elapsed_seconds
+
+
+def load_live_counter_totals(machine_id):
+    """Return total objects removed for each counter from live metrics CSV."""
+    file_path = os.path.join(
+        hourly_data_saving.EXPORT_DIR,
+        str(machine_id),
+        hourly_data_saving.METRICS_FILENAME,
+    )
+
+    df = df_processor.safe_read_csv(file_path)
+
+    totals = []
+    for i in range(1, 13):
+        col = f"counter_{i}"
+        if col in df.columns:
+            stats = generate_report.calculate_total_objects_from_csv_rates(df[col])
+            totals.append(stats.get("total_objects", 0))
+        else:
+            totals.append(0)
+
+    return totals
 
 
 def register_callbacks(app):
@@ -2363,11 +2409,32 @@ def _register_callbacks_impl(app):
 
         elif mode == "lab":
             mid = active_machine_id
-            metrics = load_lab_totals_metrics(mid) if mid is not None else None
             capacity_count = accepts_count = reject_count = 0
+
+            machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(mid))
+            files = glob.glob(os.path.join(machine_dir, "Lab_Test_*.csv"))
+            metrics = None
+            counter_totals = None
+            object_totals = None
+            if files:
+                path = max(files, key=os.path.getmtime)
+                stat = os.stat(path)
+                cache = _lab_production_cache.get(mid)
+                if cache and cache.get("mtime") == stat.st_mtime and cache.get("size") == stat.st_size:
+                    metrics = cache["metrics"]
+                    counter_totals, _, object_totals = cache["totals"]
+                else:
+                    metrics = load_lab_totals_metrics(mid)
+                    counter_totals, _, object_totals = load_lab_totals(mid)
+                    _lab_production_cache[mid] = {
+                        "metrics": metrics,
+                        "totals": (counter_totals, [], object_totals),
+                        "mtime": stat.st_mtime,
+                        "size": stat.st_size,
+                    }
+
             if metrics:
                 tot_cap_lbs, acc_lbs, rej_lbs, _ = metrics
-                counter_totals, _, object_totals = load_lab_totals(mid)
 
                 reject_count = sum(counter_totals)
                 capacity_count = object_totals[-1] if object_totals else 0
@@ -4214,25 +4281,9 @@ def _register_callbacks_impl(app):
             previous_counter_values = new_counter_values.copy()
             logger.info(f"Section 5-2 values (lab mode): {new_counter_values}")
         elif mode in LIVE_LIKE_MODES and app_state_data.get("connected", False):
-            # Live mode: get values from OPC UA
-            # Use the tag pattern provided for each counter
-            new_counter_values = []
-            for i in range(1, 13):
-                # Construct the tag name using the provided pattern
-                tag_name = TAG_PATTERN.format(i)
-    
-                # Check if the tag exists
-                if tag_name in app_state.tags:
-                    value = app_state.tags[tag_name]["data"].latest_value
-                    if value is None:
-                        # If tag exists but value is None, keep previous value
-                        value = previous_counter_values[i-1]
-                    new_counter_values.append(value)
-                else:
-                    # Tag not found - keep previous value
-                    new_counter_values.append(previous_counter_values[i-1])
-    
-            # Store the new values for the next update
+            # Live mode: read cumulative counts from the metrics CSV
+            mid = active_machine_data.get("machine_id") if active_machine_data else None
+            new_counter_values = load_live_counter_totals(mid)
             previous_counter_values = new_counter_values.copy()
             logger.info(f"Section 5-2 values (live mode): {new_counter_values}")
         elif mode == "demo":

--- a/tests/test_live_counter_totals.py
+++ b/tests/test_live_counter_totals.py
@@ -1,0 +1,48 @@
+import os
+import os
+import sys
+import csv
+import pytest
+
+import dash
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+import autoconnect
+
+
+def setup_app(monkeypatch, tmp_path):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    monkeypatch.setattr(callbacks.hourly_data_saving, "EXPORT_DIR", str(tmp_path))
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    return app
+
+
+def create_metrics(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir(parents=True, exist_ok=True)
+    path = machine_dir / "last_24h_metrics.csv"
+    fieldnames = ["timestamp"] + [f"counter_{i}" for i in range(1, 13)]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow({"timestamp": "2025-01-01T00:00:00", "counter_1": 1})
+        writer.writerow({"timestamp": "2025-01-01T00:01:00", "counter_1": 2})
+    return path
+
+
+def test_update_section_5_2_live_uses_csv_totals(monkeypatch, tmp_path):
+    app = setup_app(monkeypatch, tmp_path)
+    create_metrics(tmp_path)
+    func = app.callback_map["section-5-2.children"]["callback"]
+
+    callbacks.previous_counter_values = [0] * 12
+    callbacks.threshold_settings = {}
+
+    res = func.__wrapped__(0, "main", {}, {}, "en", {"connected": True}, {"mode": "live"}, {"machine_id": 1})
+
+    assert callbacks.previous_counter_values[0] == pytest.approx(3)
+    bar = res.children[1]
+    assert bar.figure.data[0].y[0] == pytest.approx(3)


### PR DESCRIPTION
## Summary
- compute live counter totals from metrics CSV via `load_live_counter_totals`
- reuse these totals in section 5-2 when in live mode
- cache lab production metrics and totals to avoid recomputation
- update lab total calculations to be time-weighted
- add unit test for live counter totals

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d817e48dc8327bcc923223ee94071