### PR TITLE
Fix lab simulator flush call

### DIFF
--- a/scripts/lab_mode_sim.py
+++ b/scripts/lab_mode_sim.py
@@ -41,7 +41,7 @@ def simulate(csv_path: Path, delay: float = 0.0) -> None:
 
             for i, row in enumerate(reader, 1):
                 writer.writerow(row)
-                writer.flush()
+                dst.flush()
                 callbacks._lab_totals_cache.clear()
 
                 section, _ = update_1_1.__wrapped__(


### PR DESCRIPTION
## Summary
- fix `writer.flush` AttributeError in lab simulator by flushing the destination file handle

## Testing
- `pytest` *(fails: AttributeError in callbacks test suite)*

------
https://chatgpt.com/codex/tasks/task_e_686db0262968832783fbbe7117372995