### PR TITLE
Implement background pause in lab mode

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -509,6 +509,8 @@ def _register_callbacks_impl(app):
         "opc_update_thread",
         "auto_reconnection_thread",
         "resume_update_thread",
+        "pause_background_processes",
+        "resume_background_processes",
         "logger",
     ]:
         if name in globals():
@@ -5588,7 +5590,13 @@ def _register_callbacks_impl(app):
         """Synchronize ``current_app_mode`` with the ``app-mode`` store."""
         global current_app_mode
         if isinstance(data, dict) and "mode" in data:
-            current_app_mode = data["mode"]
+            new_mode = data["mode"]
+            if new_mode != current_app_mode:
+                current_app_mode = new_mode
+                if new_mode == "lab":
+                    pause_background_processes()
+                else:
+                    resume_background_processes()
         return dash.no_update
 
     @app.callback(

--- a/memory_leak_fixes.py
+++ b/memory_leak_fixes.py
@@ -77,14 +77,19 @@ class AppStateManager:
         self.interval = interval
         self._stop_event = threading.Event()
         self._thread = threading.Thread(target=self._loop, daemon=True)
+        self.cleanup_paused = False
 
     def start_cleanup_thread(self) -> None:
         self._thread.start()
 
+    def set_paused(self, value: bool) -> None:
+        self.cleanup_paused = value
+
     def _loop(self) -> None:
         while not self._stop_event.is_set():
             time.sleep(self.interval)
-            self.cleanup()
+            if not self.cleanup_paused:
+                self.cleanup()
 
     def cleanup(self) -> None:
         tags = getattr(self.app_state, "tags", {})


### PR DESCRIPTION
## Summary
- reduce background activity in lab mode
- skip non-fast tags when reading OPC data in lab mode
- add helpers to pause/resume reconnection and cleanup threads
- pause reconnection and cleanup when lab mode is active

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6b216f648327bd67b3c08b82fc5d