### PR TITLE
Apply lab weight multiplier in reports

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -23,6 +23,8 @@ import math  # for label angle calculations
 FONT_DEFAULT = "Helvetica"
 FONT_BOLD = "Helvetica-Bold"
 LAB_OBJECT_SCALE_FACTOR = 1.042
+# Weight conversion for lab metrics: 46 lbs per 1800 pieces
+LAB_WEIGHT_MULTIPLIER = 46 / 1800
 
 from i18n import tr
 
@@ -509,6 +511,10 @@ def draw_global_summary(
                     values_in_kg=values_in_kg,
                 )
                 total_rejects += stats['total_capacity_lbs']
+
+    if is_lab_mode:
+        total_accepts *= LAB_WEIGHT_MULTIPLIER
+        total_rejects *= LAB_WEIGHT_MULTIPLIER
 
     # Section 1: Totals
     y_sec1 = current_y - h1
@@ -1194,6 +1200,10 @@ def draw_machine_sections(
             values_in_kg=values_in_kg,
         )
         machine_rejects = r_stats["total_capacity_lbs"]
+
+    if is_lab_mode:
+        machine_accepts *= LAB_WEIGHT_MULTIPLIER
+        machine_rejects *= LAB_WEIGHT_MULTIPLIER
 
     
     # Draw SMALLER blue counts section

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -199,8 +199,11 @@ def test_draw_machine_sections_lab_mode_decimals(tmp_path, monkeypatch):
         df["rejects"], timestamps=df["timestamp"], is_lab_mode=True
     )
 
-    assert f"{a_stats['total_capacity_lbs']:.2f} lbs" in canvas.strings
-    assert f"{r_stats['total_capacity_lbs']:.2f} lbs" in canvas.strings
+    expected_accepts = a_stats['total_capacity_lbs'] * generate_report.LAB_WEIGHT_MULTIPLIER
+    expected_rejects = r_stats['total_capacity_lbs'] * generate_report.LAB_WEIGHT_MULTIPLIER
+
+    assert f"{expected_accepts:.2f} lbs" in canvas.strings
+    assert f"{expected_rejects:.2f} lbs" in canvas.strings
 
 
 def test_global_summary_totals_sum_machines(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add LAB_WEIGHT_MULTIPLIER constant
- scale accept and reject totals with the multiplier in lab mode
- adjust lab-mode report test expectations

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ea5fb46688327995fb5070ff49566