### PR TITLE
Implement y-axis limit for counter trends

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4760,6 +4760,15 @@ def _register_callbacks_impl(app):
             hist_values = [historical_data[i]['values'][-1] if historical_data[i]['values'] else None for i in range(1, 13)]
             logger.info(f"Section 6-1 latest values (historical mode): {hist_values}")
 
+            max_hist_value = 0
+            for i in range(1, 13):
+                if display_settings.get(i, True):
+                    vals = historical_data[i]["values"]
+                    if vals:
+                        max_hist_value = max(max_hist_value, max(vals))
+
+            yaxis_range = [0, 1] if max_hist_value < 1 else [0, None]
+
             fig.update_layout(
                 title=None,
                 xaxis=dict(
@@ -4774,7 +4783,7 @@ def _register_callbacks_impl(app):
                     title=None,
                     showgrid=False,
                     gridcolor='rgba(211,211,211,0.3)',
-                    range=[0, None],
+                    range=yaxis_range,
                 ),
                 margin=dict(l=5, r=5, t=5, b=5),
                 height=200,
@@ -4844,6 +4853,15 @@ def _register_callbacks_impl(app):
                         hovertext=[f"{counter_name}: {value}" for value in values],
                     ))
 
+        max_live_value = 0
+        for i in range(1, 13):
+            if display_settings.get(i, True):
+                vals = app_state.counter_history[i]["values"]
+                if vals:
+                    max_live_value = max(max_live_value, max(vals))
+
+        yaxis_range = [0, 1] if max_live_value < 1 else [0, None]
+
         fig.update_layout(
             title=None,
             xaxis=dict(
@@ -4859,7 +4877,7 @@ def _register_callbacks_impl(app):
                 title=None,
                 showgrid=False,
                 gridcolor='rgba(211,211,211,0.3)',
-                range=[0, None],
+                range=yaxis_range,
             ),
             margin=dict(l=5, r=5, t=5, b=5),
             height=200,

--- a/tests/test_update_section_6_1.py
+++ b/tests/test_update_section_6_1.py
@@ -47,3 +47,24 @@ def test_update_section_6_1_yaxis_min_zero(monkeypatch):
 
     graph = div.children[1]
     assert graph.figure.layout.yaxis.range[0] == 0
+    assert graph.figure.layout.yaxis.range[1] is None
+
+
+def test_update_section_6_1_yaxis_max_one(monkeypatch):
+    """Ensure y-axis upper bound defaults to 1 when all values are below 1."""
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["section-6-1.children"]["callback"]
+
+    monkeypatch.setattr(callbacks.counter_manager, "add_data_point", lambda *a, **k: None, raising=False)
+
+    callbacks.previous_counter_values = [0.5] * 12
+    callbacks.display_settings = {i: True for i in range(1, 13)}
+    callbacks.app_state.counter_history = {i: {"times": [], "values": []} for i in range(1, 13)}
+
+    div = func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "demo"}, {"machine_id": 1})
+
+    graph = div.children[1]
+    assert graph.figure.layout.yaxis.range == (0, 1)


### PR DESCRIPTION
## Summary
- keep counter trend y-axis fixed at 0-1 when counters remain below 1
- automatically expand y-axis once counters exceed 1
- test for default upper bound when counters are small

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec15cc5c483278dd71998e6c11e84