### PR TITLE
Clamp small metrics when logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ python3 scripts/lab_mode_sim.py tests/Lab_Test_NEWTEST1_07_07_2025.csv
 
 As the code is refactored into modules, the entry point and command-line options will remain consistent so that users experience no change in behavior.
 
+## Logging Metrics
+
+During lab tests the application writes metric values to CSV files. Values whose
+absolute magnitude is below `SMALL_VALUE_THRESHOLD` (default `0.001`) are stored
+as `0` to avoid noise from very small readings. Adjust the constant in
+`callbacks.py` if different behavior is desired.
+
 ## Running with Gunicorn
 
 For production deployments you can run the Dash application using Gunicorn.


### PR DESCRIPTION
## Summary
- ignore small metric values when logging
- document the new small-value threshold in README
- test that tiny values are clamped to zero

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec1b3e6e8832796e197343692ab66