### PR TITLE
Add counter index offset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ absolute magnitude is below `SMALL_VALUE_THRESHOLD` (default `0.001`) are stored
 as `0` to avoid noise from very small readings. Adjust the constant in
 `callbacks.py` if different behavior is desired.
 
+If your machine numbers counters starting at zero instead of one, set the
+`COUNTER_INDEX_OFFSET` environment variable to `-1`. This shifts the OPC UA tag
+names so that `counter_1` reads `DefectCount0.Rate.Current` and prevents data
+from appearing under the wrong counter columns.
+
 ## Running with Gunicorn
 
 For production deployments you can run the Dash application using Gunicorn.

--- a/callbacks.py
+++ b/callbacks.py
@@ -69,6 +69,11 @@ current_lab_filename = None
 # Any metric whose absolute value is below this threshold will be logged as 0.
 SMALL_VALUE_THRESHOLD = 1e-3
 
+# Offset applied when mapping counter numbers to OPC UA tag names.  Set the
+# ``COUNTER_INDEX_OFFSET`` environment variable to ``-1`` when counters are
+# zero-based on the machine so that ``counter_1`` reads ``DefectCount0``.
+COUNTER_INDEX_OFFSET = int(os.environ.get("COUNTER_INDEX_OFFSET", "0"))
+
 # Flag to prevent re-entrancy when the legacy module imports this module and
 # executes ``register_callbacks`` during import.
 _REGISTERING = False
@@ -4529,7 +4534,7 @@ def _register_callbacks_impl(app):
             new_counter_values = []
             for i in range(1, 13):
                 # Construct the tag name using the provided pattern
-                tag_name = TAG_PATTERN.format(i)
+                tag_name = TAG_PATTERN.format(i + COUNTER_INDEX_OFFSET)
     
                 # Check if the tag exists
                 if tag_name in app_state.tags:
@@ -5910,7 +5915,7 @@ def _register_callbacks_impl(app):
             reject_count = 0
             counters = {}
             for i in range(1, 13):
-                tname = COUNTER_TAG.format(i)
+                tname = COUNTER_TAG.format(i + COUNTER_INDEX_OFFSET)
                 val = tags.get(tname, {}).get("data").latest_value if tname in tags else 0
                 if val is None:
                     val = 0


### PR DESCRIPTION
## Summary
- allow offsetting counter tag numbers via `COUNTER_INDEX_OFFSET`
- mention the new environment variable in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ec7981e508327a9841a2b27d7d19a