### PR TITLE
Restore lab logging tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ is useful for troubleshooting discrepancies without running the full UI.
 python3 scripts/lab_mode_sim.py tests/Lab_Test_NEWTEST1_07_07_2025.csv
 ```
 
+
 As the code is refactored into modules, the entry point and command-line options will remain consistent so that users experience no change in behavior.
+
+## Logging Metrics
+
+During lab tests the application writes metric values to CSV files. Values whose
+absolute magnitude is below `SMALL_VALUE_THRESHOLD` (default `0.001`) are
+recorded as `0` to avoid noise from very small readings. Adjust the constant in
+`callbacks.py` if different behavior is desired.
 
 ## Running with Gunicorn
 

--- a/callbacks.py
+++ b/callbacks.py
@@ -81,6 +81,9 @@ last_logged_capacity = defaultdict(lambda: None)
 # Filename used for the active lab test session
 current_lab_filename = None
 
+# Any metric whose absolute value is below this threshold will be logged as 0.
+SMALL_VALUE_THRESHOLD = 1e-3
+
 # Flag to prevent re-entrancy when the legacy module imports this module and
 # executes ``register_callbacks`` during import.
 _REGISTERING = False
@@ -4815,7 +4818,7 @@ def _register_callbacks_impl(app):
                     if vals:
                         max_hist_value = max(max_hist_value, max(vals))
 
-            yaxis_range = [0, 10] if max_hist_value < 1 else [0, None]
+            yaxis_range = [0, 10] if max_hist_value < 10 else [0, None]
 
             fig.update_layout(
                 title=None,
@@ -4908,7 +4911,7 @@ def _register_callbacks_impl(app):
                 if vals:
                     max_live_value = max(max_live_value, max(vals))
 
-        yaxis_range = [0, 1] if max_live_value < 1 else [0, None]
+        yaxis_range = [0, 10] if max_live_value < 10 else [0, None]
 
         fig.update_layout(
             title=None,
@@ -5989,10 +5992,11 @@ def _register_callbacks_impl(app):
 
             log_mode = "Lab" if mode == "lab" else "Live"
             if mode == "lab":
-                # Clamp negative values when logging lab data
+                # Clamp negative or extremely small values when logging lab data
                 for key, value in metrics.items():
-                    if isinstance(value, (int, float)) and value < 0:
-                        metrics[key] = 0
+                    if isinstance(value, (int, float)):
+                        if value < 0 or abs(value) < SMALL_VALUE_THRESHOLD:
+                            metrics[key] = 0
                 append_metrics(
                     metrics,
                     machine_id=str(machine_id),

--- a/tests/test_update_section_6_1.py
+++ b/tests/test_update_section_6_1.py
@@ -67,4 +67,4 @@ def test_update_section_6_1_yaxis_max_one(monkeypatch):
     div = func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "demo"}, {"machine_id": 1})
 
     graph = div.children[1]
-    assert graph.figure.layout.yaxis.range == (0, 1)
+    assert graph.figure.layout.yaxis.range == (0, 10)


### PR DESCRIPTION
## Summary
- reintroduce small metric clamping when logging
- increase Section 6-1 default y-axis scale to 10
- document metric logging threshold
- update tests

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb2fd9ca08327b84861c2ab4424f1