### PR TITLE
Restore lab logging tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ is useful for troubleshooting discrepancies without running the full UI.
 python3 scripts/lab_mode_sim.py tests/Lab_Test_NEWTEST1_07_07_2025.csv
 ```
 
+
 As the code is refactored into modules, the entry point and command-line options will remain consistent so that users experience no change in behavior.
+
+## Logging Metrics
+
+During lab tests the application writes metric values to CSV files. Values whose
+absolute magnitude is below `SMALL_VALUE_THRESHOLD` (default `0.001`) are
+recorded as `0` to avoid noise from very small readings. Adjust the constant in
+`callbacks.py` if different behavior is desired.
 
 ## Running with Gunicorn
 

--- a/tests/test_purge_old_entries.py
+++ b/tests/test_purge_old_entries.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from hourly_data_saving import append_metrics, purge_old_entries, METRICS_FILENAME
 
 
-def test_header_rebuild_with_extra_columns(tmp_path):
+def test_purge_old_entries_preserves_header(tmp_path):
     machine_id = "1"
     machine_dir = tmp_path / machine_id
     machine_dir.mkdir(parents=True, exist_ok=True)
@@ -35,21 +35,13 @@ def test_header_rebuild_with_extra_columns(tmp_path):
         "stopped": 0,
     }
 
-    # Append metrics including new columns
     append_metrics(metrics, machine_id, export_dir=str(tmp_path))
 
-    # Ensure cleanup updates header
-    purge_old_entries(export_dir=str(tmp_path), machine_id=machine_id,
-                      fieldnames_hint=["timestamp"] + list(metrics.keys()) + ["mode"])
+    # Cleanup should not alter the original header
+    purge_old_entries(export_dir=str(tmp_path), machine_id=machine_id)
 
     with file_path.open() as f:
         rows = list(csv.reader(f))
 
-    header = rows[0]
-    assert "running" in header and "stopped" in header
-    data = rows[-1]
-    idx_run = header.index("running")
-    idx_stop = header.index("stopped")
-    assert data[idx_run] == "1"
-    assert data[idx_stop] == "0"
+    assert rows[0] == header
 

--- a/tests/test_update_section_6_1.py
+++ b/tests/test_update_section_6_1.py
@@ -67,4 +67,4 @@ def test_update_section_6_1_yaxis_max_one(monkeypatch):
     div = func.__wrapped__(0, "main", {}, "en", {"connected": True}, {"mode": "demo"}, {"machine_id": 1})
 
     graph = div.children[1]
-    assert graph.figure.layout.yaxis.range == (0, 1)
+    assert graph.figure.layout.yaxis.range == (0, 10)


### PR DESCRIPTION
## Summary
- reintroduce small metric clamping when logging
- increase Section 6-1 default y-axis scale to 10
- document metric logging threshold
- restore 30s stop button grace period
- simplify log cleanup and remove header rewrite test

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb2fd9ca08327b84861c2ab4424f1