### PR TITLE
Add auto start/stop logic for lab tests

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5487,7 +5487,7 @@ def _register_callbacks_impl(app):
         prevent_initial_call=True,
     )
     def update_lab_running(start_click, stop_click, mode, n_intervals, running, stop_time):
-        """Update lab running state based on start/stop actions."""
+        """Update lab running state based on start/stop actions or feeder status."""
         global current_lab_filename
         ctx = callback_context
 
@@ -5507,6 +5507,27 @@ def _register_callbacks_impl(app):
                 # Do not end the test immediately; allow a 30s grace period
                 # so logging can continue before finalizing.
                 return True
+
+        # Auto-start when any feeder begins running
+        feeders_running = False
+        if (
+            active_machine_id is not None
+            and active_machine_id in machine_connections
+        ):
+            tags = machine_connections[active_machine_id].get("tags", {})
+            for i in range(1, 5):
+                tag = f"Status.Feeders.{i}IsRunning"
+                if bool(tags.get(tag, {}).get("data", {}).latest_value if tag in tags else False):
+                    feeders_running = True
+                    break
+
+        if feeders_running and not running:
+            try:
+                if active_machine_id is not None:
+                    _reset_lab_session(active_machine_id)
+            except Exception as exc:
+                logger.warning(f"Failed to reset lab session: {exc}")
+            return True
 
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - stop_time >= 30):
@@ -5557,17 +5578,46 @@ def _register_callbacks_impl(app):
 
     @app.callback(
         Output("lab-test-stop-time", "data"),
-        [Input("start-test-btn", "n_clicks"), Input("stop-test-btn", "n_clicks")],
+        [Input("start-test-btn", "n_clicks"),
+         Input("stop-test-btn", "n_clicks"),
+         Input("status-update-interval", "n_intervals")],
+        [State("lab-test-running", "data"),
+         State("lab-test-stop-time", "data"),
+         State("app-mode", "data"),
+         State("active-machine-store", "data")],
         prevent_initial_call=True,
     )
-    def update_lab_test_stop_time(start_click, stop_click):
+    def update_lab_test_stop_time(start_click, stop_click, n_intervals, running, stop_time, mode, active_machine_data):
         ctx = callback_context
-        if not ctx.triggered:
-            raise PreventUpdate
-        trigger = ctx.triggered[0]["prop_id"].split(".")[0]
-        if trigger == "stop-test-btn":
+        if ctx.triggered:
+            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+            if trigger == "stop-test-btn":
+                return time.time()
+            if trigger == "start-test-btn":
+                return None
+
+        if not running:
+            return dash.no_update
+
+        if not mode or mode.get("mode") != "lab":
+            return dash.no_update
+
+        active_id = active_machine_data.get("machine_id") if active_machine_data else None
+        if not active_id or active_id not in machine_connections:
+            return dash.no_update
+
+        tags = machine_connections[active_id].get("tags", {})
+        any_running = False
+        for i in range(1, 5):
+            tag = f"Status.Feeders.{i}IsRunning"
+            if bool(tags.get(tag, {}).get("data", {}).latest_value if tag in tags else False):
+                any_running = True
+                break
+
+        if not any_running and stop_time is None:
             return time.time()
-        return None
+
+        return dash.no_update
 
     @app.callback(
         Output("clear-data-btn", "n_clicks"),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -204,3 +204,52 @@ def test_generate_report_disable_callback(monkeypatch):
 
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
     assert func.__wrapped__(0, False, 50) is False
+
+
+def test_lab_auto_start(monkeypatch):
+    """Lab mode should start automatically when any feeder is running."""
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    func = app.callback_map["lab-test-running.data"]["callback"]
+
+    tag = callbacks.TagData("Status.Feeders.1IsRunning")
+    tag.latest_value = True
+    callbacks.machine_connections = {
+        1: {"tags": {"Status.Feeders.1IsRunning": {"data": tag}}, "connected": True}
+    }
+    callbacks.active_machine_id = 1
+
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("status-update-interval.n_intervals"))
+    res = func.__wrapped__(None, None, "lab", 1, False, None)
+    assert res is True
+
+
+def test_lab_auto_stop_sets_time(monkeypatch):
+    """Stop time should be recorded when all feeders stop running."""
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    func = app.callback_map["lab-test-stop-time.data"]["callback"]
+
+    tag = callbacks.TagData("Status.Feeders.1IsRunning")
+    tag.latest_value = False
+    callbacks.machine_connections = {
+        1: {"tags": {"Status.Feeders.1IsRunning": {"data": tag}}, "connected": True}
+    }
+    callbacks.active_machine_id = 1
+
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("status-update-interval.n_intervals"))
+    monkeypatch.setattr(callbacks.time, "time", lambda: 123.0)
+    res = func.__wrapped__(None, None, 1, True, None, {"mode": "lab"}, {"machine_id": 1})
+    assert res == 123.0


### PR DESCRIPTION
## Summary
- start lab tests automatically when any feeder runs
- stop lab tests when feeders stop running
- test new behaviour in `test_callbacks`

## Testing
- `pytest tests/test_callbacks.py::test_lab_auto_start -q`
- `pytest tests/test_callbacks.py::test_lab_auto_stop_sets_time -q`
- `pytest -q` *(fails: test_generate_report.py::test_draw_global_summary_totals, test_draw_machine_sections_lab_mode_decimals, test_objects_per_min_totals_match, test_global_summary_lab_weights_from_objects)*

------
https://chatgpt.com/codex/tasks/task_e_687007c291f8832795836b3290d60c08