### PR TITLE
Add auto start/stop logic for lab tests

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -204,3 +204,53 @@ def test_generate_report_disable_callback(monkeypatch):
 
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
     assert func.__wrapped__(0, False, 50) is False
+
+
+def test_lab_auto_start(monkeypatch):
+    """Lab mode should start automatically when any feeder is running."""
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    func = app.callback_map["lab-test-running.data"]["callback"]
+
+    tag = callbacks.TagData("Status.Feeders.1IsRunning")
+    tag.latest_value = True
+    callbacks.machine_connections = {
+        1: {"tags": {"Status.Feeders.1IsRunning": {"data": tag}}, "connected": True}
+    }
+    callbacks.active_machine_id = 1
+
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("status-update-interval.n_intervals"))
+    res = func.__wrapped__(None, None, "lab", 1, False, None, "Auto")
+    assert res is True
+    assert callbacks.current_lab_filename and callbacks.current_lab_filename.endswith(".csv")
+
+
+def test_lab_auto_stop_sets_time(monkeypatch):
+    """Stop time should be recorded when all feeders stop running."""
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    func = app.callback_map["lab-test-stop-time.data"]["callback"]
+
+    tag = callbacks.TagData("Status.Feeders.1IsRunning")
+    tag.latest_value = False
+    callbacks.machine_connections = {
+        1: {"tags": {"Status.Feeders.1IsRunning": {"data": tag}}, "connected": True}
+    }
+    callbacks.active_machine_id = 1
+
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("status-update-interval.n_intervals"))
+    monkeypatch.setattr(callbacks.time, "time", lambda: 123.0)
+    res = func.__wrapped__(None, None, 1, True, None, {"mode": "lab"}, {"machine_id": 1})
+    assert res == 123.0


### PR DESCRIPTION
## Summary
- start lab tests automatically when any feeder runs
- stop lab tests when feeders stop running
- test new behaviour in `test_callbacks`
- ensure lab auto-start creates a log file

## Testing
- `pytest tests/test_callbacks.py::test_lab_auto_start -q`
- `pytest tests/test_callbacks.py::test_lab_auto_stop_sets_time -q`
- `pytest -q` *(fails: test_generate_report.py::test_draw_global_summary_totals, test_draw_machine_sections_lab_mode_decimals, test_objects_per_min_totals_match, test_global_summary_lab_weights_from_objects)*

------
https://chatgpt.com/codex/tasks/task_e_687007c291f8832795836b3290d60c08