### PR TITLE
Fix lab auto-start with feeder status

### DIFF
--- a/tests/test_lab_logging.py
+++ b/tests/test_lab_logging.py
@@ -46,7 +46,7 @@ def test_lab_logging_uses_single_file(monkeypatch):
             self.triggered = [{"prop_id": prop_id}]
 
     monkeypatch.setattr(callbacks, "callback_context", DummyCtx("start-test-btn"))
-    info = start_func.__wrapped__(1, None, "MyTest")
+    info = start_func.__wrapped__(1, None, 0, "MyTest", False, None, {})
     assert "filename" in info
 
     log_func.__wrapped__(0, {"connected": True}, {"mode": "lab"}, None, None, {"unit": "lb"}, True, {"machine_id": 1}, info)
@@ -82,12 +82,12 @@ def test_lab_stop_retains_filename(monkeypatch):
             self.triggered = [{"prop_id": prop_id}]
 
     monkeypatch.setattr(callbacks, "callback_context", DummyCtx("start-test-btn"))
-    start_info = info_func.__wrapped__(1, None, "MyStopTest")
+    start_info = info_func.__wrapped__(1, None, 0, "MyStopTest", False, None, {})
     assert "filename" in start_info
 
     # simulate pressing stop
     monkeypatch.setattr(callbacks, "callback_context", DummyCtx("stop-test-btn"))
-    stop_info = info_func.__wrapped__(None, 1, "")
+    stop_info = info_func.__wrapped__(None, 1, 0, "", True, None, start_info)
     assert stop_info == {}
 
     # log metrics while the lab test is still considered running


### PR DESCRIPTION
## Summary
- revert prior callback changes
- auto start/stop lab tests when feeders run
- update callbacks to create log files on auto start
- adjust tests for new callback signatures and add coverage

## Testing
- `pytest -q` *(fails: test_draw_global_summary_totals, test_draw_machine_sections_lab_mode_decimals, test_objects_per_min_totals_match, test_global_summary_lab_weights_from_objects)*

------
https://chatgpt.com/codex/tasks/task_e_687007c291f8832795836b3290d60c08