### PR TITLE
Fix lab test running callback

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5484,8 +5484,7 @@ def _register_callbacks_impl(app):
          Input("mode-selector", "value"),
          Input("status-update-interval", "n_intervals")],
         [State("lab-test-running", "data"),
-         State("lab-test-stop-time", "data"),
-         State("lab-test-name", "value")],
+         State("lab-test-stop-time", "data")],
         prevent_initial_call=True,
     )
 


### PR DESCRIPTION
## Summary
- fix update_lab_running callback state list

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q` *(fails: test_generate_report.py::test_draw_global_summary_totals et al.)*

------
https://chatgpt.com/codex/tasks/task_e_687022c716c8832781e55783e1823e3d