### PR TITLE
Fix settings lookup in report

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -44,6 +44,13 @@ def _lookup_setting(data: dict, dotted_key: str, default="N/A"):
         Value returned when the key path does not exist.
     """
 
+    if not isinstance(data, dict):
+        return default
+
+    # First check for a flat key using dotted notation
+    if dotted_key in data:
+        return data[dotted_key]
+
     cur = data
     for part in dotted_key.split("."):
         if isinstance(cur, dict) and part in cur:
@@ -991,10 +998,10 @@ def draw_machine_settings_section(c, x0, y0, total_w, section_h, settings, *, la
     # Map each cell to the start of its merge region
     merged_to = {}
 
-    for (r, c), (rs, cs) in merges.items():
+    for (r, c_idx), (rs, cs) in merges.items():
         for rr in range(r, r + rs):
-            for cc in range(c, c + cs):
-                merged_to[(rr, cc)] = (r, c)
+            for cc in range(c_idx, c_idx + cs):
+                merged_to[(rr, cc)] = (r, c_idx)
 
 
     # Draw base grid
@@ -1007,8 +1014,8 @@ def draw_machine_settings_section(c, x0, y0, total_w, section_h, settings, *, la
 
     # Overlay merged cell rectangles to hide interior lines
 
-    for (r, c), (rs, cs) in merges.items():
-        x = x0 + c * col_w
+    for (r, c_idx), (rs, cs) in merges.items():
+        x = x0 + c_idx * col_w
         y = y0 + section_h - (r + rs) * row_h
         w = cs * col_w
         h = rs * row_h
@@ -1021,7 +1028,7 @@ def draw_machine_settings_section(c, x0, y0, total_w, section_h, settings, *, la
     # Draw cell text with optional blue background for missing values
     for r, row in enumerate(data):
         for j, cell in enumerate(row):
-            if merged_to.get((r, j)) != (r, j):
+            if merged_to.get((r, j), (r, j)) != (r, j):
                 # Skip cells that are part of a merge but not the top-left
                 continue
             rs, cs = merges.get((r, j), (1, 1))
@@ -1047,6 +1054,8 @@ def draw_machine_settings_section(c, x0, y0, total_w, section_h, settings, *, la
             else:
                 c.setFont(FONT_DEFAULT, 6)
             c.drawString(tx, ty, text)
+
+    c.restoreState()
 
 
 

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -20,6 +20,12 @@ def test_lookup_setting_nested():
     assert generate_report._lookup_setting(data, "Missing.Key") == "N/A"
 
 
+def test_lookup_setting_flat_keys():
+    flat = {"Settings.Ejectors.PrimaryDelay": 10}
+    assert generate_report._lookup_setting(flat, "Settings.Ejectors.PrimaryDelay") == 10
+    assert generate_report._lookup_setting(flat, "Missing.Key") == "N/A"
+
+
 def test_load_machine_settings(tmp_path):
     machine_dir = tmp_path / "1"
     machine_dir.mkdir()


### PR DESCRIPTION
## Summary
- support flat dotted keys when reading machine settings
- test that `_lookup_setting` handles both nested and flat formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871aa1347b88327b6486a075b5cfba3