### PR TITLE
Add sensitivity grid section to reports

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -180,6 +180,22 @@ KNOWN_TAGS = {
     "Settings.Calibration.FrontBackgroundRed": "ns=2;s=Settings.Calibration.FrontBackgroundRed",
     "Settings.Calibration.FrontBackgroundGreen": "ns=2;s=Settings.Calibration.FrontBackgroundGreen",
     "Settings.Calibration.FrontBackgroundBlue": "ns=2;s=Settings.Calibration.FrontBackgroundBlue",
+    # Sensitivity specific tags for PDF reports
+    **{f"Settings.ColorSort.Primary{i}.FrontAndRearLogic": f"ns=2;s=Settings.ColorSort.Primary{i}.FrontAndRearLogic" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidCenterX": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidCenterX" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidCenterY": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidCenterY" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidCenterZ": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidCenterZ" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EjectorDelayOffset": f"ns=2;s=Settings.ColorSort.Primary{i}.EjectorDelayOffset" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.Sensitivity": f"ns=2;s=Settings.ColorSort.Primary{i}.Sensitivity" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthX": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidAxisLengthX" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthY": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidAxisLengthY" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthZ": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidAxisLengthZ" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EjectorDwellOffset": f"ns=2;s=Settings.ColorSort.Primary{i}.EjectorDwellOffset" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.TypeId": f"ns=2;s=Settings.ColorSort.Primary{i}.TypeId" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidRotationX": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidRotationX" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidRotationY": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidRotationY" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.EllipsoidRotationZ": f"ns=2;s=Settings.ColorSort.Primary{i}.EllipsoidRotationZ" for i in range(1, 13)},
+    **{f"Settings.ColorSort.Primary{i}.AreaSize": f"ns=2;s=Settings.ColorSort.Primary{i}.AreaSize" for i in range(1, 13)},
 }
 
 # Tags that are updated on every cycle in live mode. These names come from

--- a/report_tags.py
+++ b/report_tags.py
@@ -19,6 +19,55 @@ REPORT_SETTINGS_TAGS = {
     "Settings.Calibration.FrontBackgroundRed",
     "Settings.Calibration.FrontBackgroundGreen",
     "Settings.Calibration.FrontBackgroundBlue",
+    # Sensitivity specific tags for PDF reports
+    *{
+        f"Settings.ColorSort.Primary{i}.FrontAndRearLogic" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidCenterX" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidCenterY" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidCenterZ" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EjectorDelayOffset" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.Sensitivity" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthX" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthY" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidAxisLengthZ" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EjectorDwellOffset" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.TypeId" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidRotationX" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidRotationY" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.EllipsoidRotationZ" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.AreaSize" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.IsActive" for i in range(1, 13)
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- extend list of OPC tags saved for PDF reports
- include sensitivity-related tags in legacy tag map
- add functions to render sensitivity grids in generated PDF reports
- display these grids after machine settings when generating reports

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871bd72683883278b9fd1fd8adaa4df