### PR TITLE
Fix sensitivity assignment tags for reports

### DIFF
--- a/report_tags.py
+++ b/report_tags.py
@@ -68,6 +68,9 @@ REPORT_SETTINGS_TAGS = {
     *{
         f"Settings.ColorSort.Primary{i}.IsActive" for i in range(1, 13)
     },
+    *{
+        f"Settings.ColorSort.Primary{i}.IsAssigned" for i in range(1, 13)
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- include sensitivity `IsAssigned` tags when saving machine settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d26369b88327861fcaf0fcca563b