### PR TITLE
Update lab report sensitivity refresh

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -879,7 +879,12 @@ def _register_callbacks_impl(app):
             temp_machine_dir = os.path.join(temp_dir, str(mid))
             os.makedirs(temp_machine_dir, exist_ok=True)
             shutil.copy(latest_file, os.path.join(temp_machine_dir, "last_24h_metrics.csv"))
-            save_machine_settings(mid, machine_connections, export_dir=temp_dir)
+            save_machine_settings(
+                mid,
+                machine_connections,
+                export_dir=temp_dir,
+                active_only=True,
+            )
             export_dir = temp_dir
             data = {}
             is_lab_mode = True  # Set to True only for lab mode

--- a/report_tags.py
+++ b/report_tags.py
@@ -74,15 +74,60 @@ REPORT_SETTINGS_TAGS = {
 }
 
 
-def save_machine_settings(machine_id, machine_connections, export_dir=METRIC_EXPORT_DIR):
-    """Save current REPORT_SETTINGS_TAGS values for a machine."""
+import re
+
+
+def _primary_num(name: str) -> int | None:
+    """Return the primary number encoded in a tag name or ``None``."""
+    m = re.search(r"Primary(\d+)", name)
+    if m:
+        try:
+            return int(m.group(1))
+        except Exception:  # pragma: no cover - regex group not numeric
+            return None
+    return None
+
+
+def save_machine_settings(machine_id, machine_connections, export_dir=METRIC_EXPORT_DIR, *, active_only=False):
+    """Save current REPORT_SETTINGS_TAGS values for a machine.
+
+    If ``active_only`` is ``True``, sensitivity specific tags (except the
+    ``IsActive`` and ``IsAssigned`` flags) are only saved for sensitivities that
+    are currently active according to the OPC tags.
+    """
+
     info = machine_connections.get(str(machine_id)) or machine_connections.get(machine_id)
     if not info or "tags" not in info:
         return None
 
     tags = info["tags"]
+
+    active_set = set(range(1, 13))
+    if active_only:
+        active_set.clear()
+        for i in range(1, 13):
+            flag_name = f"Settings.ColorSort.Primary{i}.IsAssigned"
+            tag = tags.get(flag_name)
+            if not tag:
+                continue
+            try:
+                val = tag["node"].get_value()
+            except Exception:
+                val = getattr(tag["data"], "latest_value", None)
+            if bool(val):
+                active_set.add(i)
+
     settings = {}
     for name in REPORT_SETTINGS_TAGS:
+        num = _primary_num(name)
+        if (
+            active_only
+            and num is not None
+            and name.endswith((".IsActive", ".IsAssigned")) is False
+            and num not in active_set
+        ):
+            continue
+
         tag = tags.get(name)
         if not tag:
             continue

--- a/tests/test_report_tags.py
+++ b/tests/test_report_tags.py
@@ -27,3 +27,30 @@ def test_save_machine_settings(tmp_path):
     data = json.loads(settings_file.read_text())
     for name, val in value_map.items():
         assert data[name] == val
+
+
+def test_save_machine_settings_active_only(tmp_path):
+    mod = importlib.import_module(module_name)
+    tags = {
+        "Settings.Ejectors.PrimaryDelay": {"node": DummyNode(1), "data": mod.TagData("d")},
+        "Settings.ColorSort.Primary1.Sensitivity": {"node": DummyNode(10), "data": mod.TagData("s1")},
+        "Settings.ColorSort.Primary1.IsAssigned": {"node": DummyNode(True), "data": mod.TagData("a1")},
+        "Settings.ColorSort.Primary2.Sensitivity": {"node": DummyNode(20), "data": mod.TagData("s2")},
+        "Settings.ColorSort.Primary2.IsAssigned": {"node": DummyNode(False), "data": mod.TagData("a2")},
+    }
+    connections = {
+        "1": {"client": object(), "tags": tags, "connected": True, "last_update": None}
+    }
+
+    report_tags.save_machine_settings(
+        "1", connections, export_dir=tmp_path, active_only=True
+    )
+
+    settings_file = Path(tmp_path) / "1" / "settings.json"
+    data = json.loads(settings_file.read_text())
+
+    assert data["Settings.Ejectors.PrimaryDelay"] == 1
+    assert data["Settings.ColorSort.Primary1.Sensitivity"] == 10
+    assert data["Settings.ColorSort.Primary1.IsAssigned"] is True
+    assert data["Settings.ColorSort.Primary2.IsAssigned"] is False
+    assert "Settings.ColorSort.Primary2.Sensitivity" not in data


### PR DESCRIPTION
## Summary
- refresh sensitivity section settings directly from OPC for active sensitivities when generating lab reports
- support optional `active_only` flag in `save_machine_settings`
- test new functionality

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871db03e07c8327b3a2a9c07ee07186