### PR TITLE
Fix lab mode report missing sensitivity data

### DIFF
--- a/report_tags.py
+++ b/report_tags.py
@@ -24,6 +24,12 @@ REPORT_SETTINGS_TAGS = {
         f"Settings.ColorSort.Primary{i}.FrontAndRearLogic" for i in range(1, 13)
     },
     *{
+        f"Settings.ColorSort.Primary{i}.SampleImage" for i in range(1, 13)
+    },
+    *{
+        f"Settings.ColorSort.Primary{i}.Name" for i in range(1, 13)
+    },
+    *{
         f"Settings.ColorSort.Primary{i}.EllipsoidCenterX" for i in range(1, 13)
     },
     *{


### PR DESCRIPTION
## Summary
- include `Settings.ColorSort.Primary*.SampleImage` and `.Name` when saving machine settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e157031083279edbd0aa0a0f3c6f