### PR TITLE
Fix lab report spacing

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1743,7 +1743,8 @@ def draw_machine_sections(
             settings_data,
             lang=lang,
         )
-        next_y = y_settings - spacing
+        settings_spacing = 10
+        next_y = y_settings - settings_spacing
 
     grid_height = 50
     next_y = draw_sensitivity_sections(


### PR DESCRIPTION
## Summary
- add more spacing after machine settings in lab mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e80001e8832795208dc4f96be8c9