### PR TITLE
Map Primary7 TypeId to label in lab reports

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1134,6 +1134,8 @@ def draw_sensitivity_grid(
 
     row_prefix = [""] if is_lab_mode else []
 
+    type_val = get(f"Settings.ColorSort.Primary{p}.TypeId")
+
     data = [
         first_row,
         [
@@ -1161,7 +1163,11 @@ def draw_sensitivity_grid(
         [
             *row_prefix,
             "Type:",
-            get(f"Settings.ColorSort.Primary{p}.TypeId"),
+            (
+                ("Ellipsoid" if str(type_val) == "0" else "Grid")
+                if is_lab_mode and p == 7
+                else type_val
+            ),
             "Angle:",
             get(f"Settings.ColorSort.Primary{p}.EllipsoidRotationX"),
             get(f"Settings.ColorSort.Primary{p}.EllipsoidRotationY"),

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -66,3 +66,41 @@ def test_draw_sensitivity_sections_only_active(monkeypatch):
     assert calls == [1, 3]
     assert end_y == 100 - 2 * (10 + 10)
 
+
+def test_primary7_typeid_label_lab_mode():
+    class DummyCanvas:
+        def __init__(self):
+            self.texts = []
+
+        def saveState(self):
+            pass
+
+        def restoreState(self):
+            pass
+
+        def setStrokeColor(self, *a, **k):
+            pass
+
+        def line(self, *a, **k):
+            pass
+
+        def rect(self, *a, **k):
+            pass
+
+        def setFillColor(self, *a, **k):
+            pass
+
+        def setFont(self, *a, **k):
+            pass
+
+        def drawString(self, x, y, text):
+            self.texts.append(text)
+
+    for value, expected in [(0, "Ellipsoid"), (1, "Grid")]:
+        c = DummyCanvas()
+        settings = {"Settings": {"ColorSort": {"Primary7": {"TypeId": value}}}}
+        generate_report.draw_sensitivity_grid(
+            c, 0, 0, 100, 20, settings, 7, is_lab_mode=True
+        )
+        assert expected in c.texts
+


### PR DESCRIPTION
## Summary
- show human-friendly text for `Settings.ColorSort.Primary7.TypeId` when generating lab mode reports
- test that `draw_sensitivity_grid` outputs `Ellipsoid` or `Grid` depending on the value

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ebee01788327b5b7bd922cdee4ff