### PR TITLE
Map any Primary TypeId to label in lab reports

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1134,6 +1134,21 @@ def draw_sensitivity_grid(
 
     row_prefix = [""] if is_lab_mode else []
 
+    type_val = get(f"Settings.ColorSort.Primary{p}.TypeId")
+    if is_lab_mode:
+        try:
+            val_int = int(float(type_val))
+        except Exception:
+            val_int = None
+        if val_int == 0:
+            type_display = "Ellipsoid"
+        elif val_int == 1:
+            type_display = "Grid"
+        else:
+            type_display = type_val
+    else:
+        type_display = type_val
+
     data = [
         first_row,
         [
@@ -1161,7 +1176,7 @@ def draw_sensitivity_grid(
         [
             *row_prefix,
             "Type:",
-            get(f"Settings.ColorSort.Primary{p}.TypeId"),
+            type_display,
             "Angle:",
             get(f"Settings.ColorSort.Primary{p}.EllipsoidRotationX"),
             get(f"Settings.ColorSort.Primary{p}.EllipsoidRotationY"),

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -66,3 +66,45 @@ def test_draw_sensitivity_sections_only_active(monkeypatch):
     assert calls == [1, 3]
     assert end_y == 100 - 2 * (10 + 10)
 
+
+def test_primary_typeid_label_lab_mode():
+    class DummyCanvas:
+        def __init__(self):
+            self.texts = []
+
+        def saveState(self):
+            pass
+
+        def restoreState(self):
+            pass
+
+        def setStrokeColor(self, *a, **k):
+            pass
+
+        def line(self, *a, **k):
+            pass
+
+        def rect(self, *a, **k):
+            pass
+
+        def setFillColor(self, *a, **k):
+            pass
+
+        def setFont(self, *a, **k):
+            pass
+
+        def drawString(self, x, y, text):
+            self.texts.append(text)
+
+    values = [0, "0", 0.0, "0.0", 1, "1", 1.0, "1.0"]
+    mapping = {0: "Ellipsoid", 1: "Grid"}
+    for raw in values:
+        expected = mapping[int(float(raw))]
+        for p in [1, 7]:
+            c = DummyCanvas()
+            settings = {"Settings": {"ColorSort": {f"Primary{p}": {"TypeId": raw}}}}
+            generate_report.draw_sensitivity_grid(
+                c, 0, 0, 100, 20, settings, p, is_lab_mode=True
+            )
+            assert expected in c.texts
+


### PR DESCRIPTION
## Summary
- map TypeId values to "Ellipsoid" or "Grid" in lab mode regardless of numeric format
- broaden test coverage for TypeId label mapping

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871ebee01788327b5b7bd922cdee4ff