### PR TITLE
Fix lab mode position text

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1119,27 +1119,27 @@ def draw_sensitivity_grid(
         position_text = "Location:"  # Default
         try:
             x_axis_wave = get(f"Settings.ColorSort.Primary{p}.XAxisWave")
-            y_axis_wave = get(f"Settings.ColorSort.Primary{p}.YAxisWave") 
+            y_axis_wave = get(f"Settings.ColorSort.Primary{p}.YAxisWave")
             z_axis_wave = get(f"Settings.ColorSort.Primary{p}.ZAxisWave")
             print(f"DEBUG Primary{p}: x_axis_wave={x_axis_wave} (type: {type(x_axis_wave)})")
-            print(f"DEBUG Primary{p}: y_axis_wave={y_axis_wave} (type: {type(y_axis_wave)})")  
+            print(f"DEBUG Primary{p}: y_axis_wave={y_axis_wave} (type: {type(y_axis_wave)})")
             print(f"DEBUG Primary{p}: z_axis_wave={z_axis_wave} (type: {type(z_axis_wave)})")
             print(f"DEBUG Primary{p}: is_grid_type={is_grid_type}, type_val={type_val}")
-            
+
             # Determine position text based on axis wave values
             if x_axis_wave is not None and y_axis_wave is not None and z_axis_wave is not None:
-                x_val = int(x_axis_wave)
-                y_val = int(y_axis_wave)
-                z_val = int(z_axis_wave)
-                
+                x_val = int(float(x_axis_wave))
+                y_val = int(float(y_axis_wave))
+                z_val = int(float(z_axis_wave))
+
                 if x_val == 9 and y_val == 7 and z_val == 8:
                     position_text = "Top Right"
                 elif x_val == 8 and y_val == 7 and z_val == 9:
                     position_text = "Top Left"
                 elif x_val == 8 and y_val == 9 and z_val == 7:
-                    position_text = "Bottom Left"
+                    position_text = "Bottom"
         except (ValueError, TypeError, Exception):
-            # If anything fails, keep default "Position:"
+            # If anything fails, keep default "Location:"
             pass
 
         if is_lab_mode:

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -110,4 +110,46 @@ def test_primary7_typeid_label_lab_mode():
         assert expected in c.texts
 
 
+def test_position_text_from_axis_wave_lab_mode():
+    class DummyCanvas:
+        def __init__(self):
+            self.texts = []
+
+        def saveState(self):
+            pass
+
+        def restoreState(self):
+            pass
+
+        def setStrokeColor(self, *a, **k):
+            pass
+
+        def line(self, *a, **k):
+            pass
+
+        def rect(self, *a, **k):
+            pass
+
+        def setFillColor(self, *a, **k):
+            pass
+
+        def setFont(self, *a, **k):
+            pass
+
+        def drawString(self, x, y, text):
+            self.texts.append(text)
+
+    cases = [
+        ({"XAxisWave": "9", "YAxisWave": "7", "ZAxisWave": "8"}, "Top Right"),
+        ({"XAxisWave": "8", "YAxisWave": "7", "ZAxisWave": "9"}, "Top Left"),
+        ({"XAxisWave": "8", "YAxisWave": "9", "ZAxisWave": "7"}, "Bottom"),
+    ]
+
+    for waves, expected in cases:
+        c = DummyCanvas()
+        settings = {"Settings": {"ColorSort": {"Primary1": {"TypeId": 1, **waves}}}}
+        generate_report.draw_sensitivity_grid(c, 0, 0, 100, 20, settings, 1, is_lab_mode=True)
+        assert expected in c.texts
+
+
 


### PR DESCRIPTION
## Summary
- map sensitivity grid axis combinations to `Top Right`, `Top Left`, or `Bottom`
- parse axis wave values as floats before converting to integers
- test lab mode position text values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f754283c8327b708eb494ab4b256