### PR TITLE
Fix duplicate progress outputs

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -847,7 +847,8 @@ def _register_callbacks_impl(app):
 
     @app.callback(
 
-        [Output("report-progress-modal", "is_open"), Output("report-progress-interval", "disabled")],
+        [Output("report-progress-modal", "is_open", allow_duplicate=True),
+         Output("report-progress-interval", "disabled", allow_duplicate=True)],
         Input("generate-report-btn", "n_clicks"),
         [State("app-mode", "data"), State("active-machine-store", "data"), State("language-preference-store", "data")],
         prevent_initial_call=True,
@@ -941,8 +942,8 @@ def _register_callbacks_impl(app):
     @app.callback(
         [Output("report-progress-message", "children"),
          Output("report-download", "data"),
-         Output("report-progress-modal", "is_open"),
-         Output("report-progress-interval", "disabled")],
+         Output("report-progress-modal", "is_open", allow_duplicate=True),
+         Output("report-progress-interval", "disabled", allow_duplicate=True)],
         Input("report-progress-interval", "n_intervals"),
         prevent_initial_call=True,
     )


### PR DESCRIPTION
## Summary
- allow duplicate outputs for report progress callbacks

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687418f82684832790d3b8dd793be692