### PR TITLE
Fix PDF report generation on Windows

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -917,10 +917,13 @@ def _register_callbacks_impl(app):
 
 
                 progress_cb("Creating machine sections")
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
+                try:
+                    tmp_path = tmp.name
+                    tmp.close()
                     generate_report.build_report(
                         data,
-                        tmp.name,
+                        tmp_path,
                         export_dir=export_dir,
                         machines=machines,
                         include_global=include_global,
@@ -928,8 +931,10 @@ def _register_callbacks_impl(app):
                         lang=lang,
                         progress_callback=progress_cb,
                     )
-                    with open(tmp.name, "rb") as f:
+                    with open(tmp_path, "rb") as f:
                         pdf_bytes = f.read()
+                finally:
+                    os.unlink(tmp_path)
 
                 if temp_dir:
                     shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- ensure temporary PDF file is closed before ReportLab writes to it
- remove the temporary file after reading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68744b43f4a483279a2b492ebb04fec6