### PR TITLE
Fix PDF report generation on subsequent runs

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -872,6 +872,7 @@ def _register_callbacks_impl(app):
 
 
         def run():
+            print("[debug] report generation thread started")
             try:
                 export_dir = generate_report.METRIC_EXPORT_DIR
                 lang = lang_store or load_language_preference()
@@ -917,10 +918,16 @@ def _register_callbacks_impl(app):
 
 
                 progress_cb("Creating machine sections")
-                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
+                os.close(fd)
+                print(
+                    f"[debug] is_lab_mode={is_lab_mode} export_dir={export_dir} machines={machines} tmp={tmp_path}"
+                )
+
+                try:
                     generate_report.build_report(
                         data,
-                        tmp.name,
+                        tmp_path,
                         export_dir=export_dir,
                         machines=machines,
                         include_global=include_global,
@@ -928,13 +935,21 @@ def _register_callbacks_impl(app):
                         lang=lang,
                         progress_callback=progress_cb,
                     )
-                    with open(tmp.name, "rb") as f:
+                    print(f"[debug] build_report finished for {tmp_path}")
+
+                    with open(tmp_path, "rb") as f:
                         pdf_bytes = f.read()
+                        print(
+                            f"[debug] read {len(pdf_bytes)} bytes from {tmp_path}"
+                        )
+                finally:
+                    os.unlink(tmp_path)
 
                 if temp_dir:
                     shutil.rmtree(temp_dir, ignore_errors=True)
 
                 progress_cb("Finalizing report")
+                print("[debug] finalizing, encoding PDF")
                 pdf_b64 = base64.b64encode(pdf_bytes).decode()
                 timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
                 _report_state["result"] = {
@@ -946,6 +961,7 @@ def _register_callbacks_impl(app):
                 _report_state["running"] = False
             except Exception as exc:  # pragma: no cover - runtime safeguard
                 logger.exception("Error generating report: %s", exc)
+                print(f"[debug] exception occurred: {exc}")
                 _report_state["progress"] = "Error generating report"
                 _report_state["result"] = None
                 _report_state["running"] = False


### PR DESCRIPTION
## Summary
- use `tempfile.mkstemp` for the temporary PDF
- keep debug logging around report generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68744b43f4a483279a2b492ebb04fec6