### PR TITLE
Fix callbacks syntax error

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -944,10 +944,6 @@ def _register_callbacks_impl(app):
                         print(
                             f"[debug] read {len(pdf_bytes)} bytes from {tmp_path}"
                         )
-                finally:
-                    os.unlink(tmp_path)
-
-
 
                 finally:
                     os.unlink(tmp_path)


### PR DESCRIPTION
## Summary
- remove stray `finally` block causing syntax error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687467a7801c832783f08db6e1a7aa4d