### PR TITLE
Add timestamp to report filenames

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1410,12 +1410,12 @@ def draw_sensitivity_sections(
 
 
 def generate_report_filename(script_dir):
-    """Generate date-stamped filename for the report"""
-    # Get current date
-    current_date = datetime.datetime.now()
-    
-    # Format: EnpresorReport_M_D_YYYY.pdf
-    date_stamp = current_date.strftime('%m_%d_%Y')
+    """Generate a time-stamped filename for the report."""
+    # Include time in the filename to avoid overwriting previous reports
+    current_time = datetime.datetime.now()
+
+    # Format: EnpresorReport_MM_DD_YYYY_HH_MM_SS.pdf
+    date_stamp = current_time.strftime('%m_%d_%Y_%H_%M_%S')
     filename = f"EnpresorReport_{date_stamp}.pdf"
     
     # Create full path


### PR DESCRIPTION
## Summary
- avoid overwriting previous reports
- use a timestamp for generated PDF filenames

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68747d33fb6883278c04e4b81d264c56