### PR TITLE
Fix title bar text case

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2972,7 +2972,7 @@ app.layout = html.Div([
             children=(
                 [
                     title_parts[0],
-                    html.Span("Enpresor", className="enpresor-font", style={"color": "red"}),
+                    html.Span("ENPRESOR", className="enpresor-font", style={"color": "red"}),
                     title_parts[1],
                 ]
                 if len((title_parts := tr("dashboard_title").split("Enpresor"))) == 2

--- a/callbacks.py
+++ b/callbacks.py
@@ -643,7 +643,7 @@ def _register_callbacks_impl(app):
         if len(parts) == 2:
             return [
                 parts[0],
-                html.Span("Enpresor", className="enpresor-font", style={"color": "red"}),
+                html.Span("ENPRESOR", className="enpresor-font", style={"color": "red"}),
                 parts[1],
             ]
         return text


### PR DESCRIPTION
## Summary
- capitalize **ENPRESOR** in `format_enpresor` helper
- update layout to show "ENPRESOR" in the page title bar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752638bc148327bf988349394c77ce