### PR TITLE
Add percent mode toggle for sensitivity chart

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -155,6 +155,8 @@ KNOWN_TAGS = {
     
     # Counter rates (1-12)
     **{f"Status.ColorSort.Sort1.DefectCount{i}.Rate.Current": f"ns=2;s=Status.ColorSort.Sort1.DefectCount{i}.Rate.Current" for i in range(1, 13)},
+    # Counter percentages (1-12) - required when displaying percent mode
+    **{f"Status.ColorSort.Sort1.DefectCount{i}.Percentage.Current": f"ns=2;s=Status.ColorSort.Sort1.DefectCount{i}.Percentage.Current" for i in range(1, 13)},
     
     # Primary color sort settings (1-12)
     **{f"Settings.ColorSort.Primary{i}.IsAssigned": f"ns=2;s=Settings.ColorSort.Primary{i}.IsAssigned" for i in range(1, 13)},
@@ -267,7 +269,8 @@ FAST_UPDATE_TAGS = {
     "Settings.ColorSort.Primary12.IsActive",
 } | {f"Status.Feeders.{i}IsRunning" for i in range(1, 5)} \
   | {f"Status.Feeders.{i}Rate" for i in range(1, 5)} \
-  | {f"Status.ColorSort.Sort1.DefectCount{i}.Rate.Current" for i in range(1, 13)}
+  | {f"Status.ColorSort.Sort1.DefectCount{i}.Rate.Current" for i in range(1, 13)} \
+  | {f"Status.ColorSort.Sort1.DefectCount{i}.Percentage.Current" for i in range(1, 13)}
 
 # How often non fast-update tags should be polled when not in live mode.
 SLOW_UPDATE_EVERY = 10
@@ -289,6 +292,7 @@ DEFAULT_THRESHOLD_SETTINGS['email_enabled'] = False
 threshold_settings = DEFAULT_THRESHOLD_SETTINGS.copy()
 DEFAULT_THRESHOLD_SETTINGS['email_address'] = ''
 DEFAULT_THRESHOLD_SETTINGS['email_minutes'] = 2  # Default 2 minutes
+DEFAULT_THRESHOLD_SETTINGS['counter_mode'] = 'counts'
 threshold_violation_state = {
     i: {
         'is_violating': False,
@@ -441,7 +445,7 @@ def load_threshold_settings():
                 # Convert string keys back to integers for internal use (except special keys)
                 settings = {}
                 for key, value in loaded_settings.items():
-                    if key in ['email_enabled', 'email_address', 'email_minutes']:
+                    if key in ['email_enabled', 'email_address', 'email_minutes', 'counter_mode']:
                         settings[key] = value
                     else:
                         settings[int(key)] = value
@@ -1236,10 +1240,12 @@ async def connect_to_server(server_url, server_name=None):
         app_state.connected = False
         return False
 
-def create_threshold_settings_form(lang=None):
+def create_threshold_settings_form(lang=None, mode=None):
     """Create a form for threshold settings."""
     if lang is None:
         lang = load_language_preference()
+    if mode is None:
+        mode = threshold_settings.get('counter_mode', 'counts')
     form_rows = []
 
     counter_colors = {
@@ -1256,6 +1262,27 @@ def create_threshold_settings_form(lang=None):
         11: "gray",
         12: "lightblue",
     }
+
+    max_limit = 5000 if mode == 'counts' else 100
+
+    # Mode toggle row
+    form_rows.append(
+        dbc.Row([
+            dbc.Col(html.Div("Display:", className="fw-bold"), width=2),
+            dbc.Col(
+                dbc.RadioItems(
+                    id="counter-mode-toggle",
+                    options=[
+                        {"label": "Counts", "value": "counts"},
+                        {"label": "Percent", "value": "percent"},
+                    ],
+                    value=mode,
+                    inline=True,
+                ),
+                width=4,
+            ),
+        ], className="mb-3")
+    )
 
     # Create row for each counter
     for i in range(1, 13):
@@ -1306,7 +1333,7 @@ def create_threshold_settings_form(lang=None):
                         type="number",
                         value=settings['max_value'],
                         min=0,
-                        max=200,
+                        max=max_limit,
                         step=1,
                         size="sm"
                     ),
@@ -1789,7 +1816,7 @@ else:  # pragma: no cover - optional dependency
 threshold_modal = dbc.Modal([
     dbc.ModalHeader(html.Span(tr("threshold_settings_title"), id="threshold-modal-header")),
     dbc.ModalBody([
-        html.Div(id="threshold-form-container", children=create_threshold_settings_form(load_language_preference()))
+        html.Div(id="threshold-form-container", children=create_threshold_settings_form(load_language_preference(), threshold_settings.get('counter_mode', 'counts')))
     ]),
     dbc.ModalFooter([
         dbc.Button(tr("close"), id="close-threshold-settings", color="secondary", className="me-2"),
@@ -2957,6 +2984,8 @@ app.layout = html.Div([
     dcc.Store(id="weight-preference-store", data=load_weight_preference()),
     dcc.Store(id="language-preference-store", data=load_language_preference()),
     dcc.Store(id="email-settings-store",   data=load_email_settings()),
+    # Store to toggle counter display between counts and percent
+    dcc.Store(id="counter-view-mode",       data="counts"),
     # Store selection for production rate units (objects or capacity)
     dcc.Store(id="production-rate-unit",    data="objects"),
     dcc.Store(id="floors-data", data=initial_floors_data),

--- a/callbacks.py
+++ b/callbacks.py
@@ -4504,10 +4504,11 @@ def _register_callbacks_impl(app):
          Input("language-preference-store", "data")],
         [State("app-state", "data"),
          State("app-mode", "data"),
-         State("active-machine-store", "data")],
+         State("active-machine-store", "data"),
+         State("counter-view-mode", "data")],
         prevent_initial_call=True
     )
-    def update_section_5_2(n_intervals, which, state_data, historical_data, lang, app_state_data, app_mode, active_machine_data):
+    def update_section_5_2(n_intervals, which, state_data, historical_data, lang, app_state_data, app_mode, active_machine_data, counter_mode):
         """Update section 5-2 with bar chart for counter values and update alarm data"""
         
         # only run when we’re in the “main” dashboard
@@ -4523,8 +4524,11 @@ def _register_callbacks_impl(app):
         # Define title for the section
         section_title = tr("sensitivity_rates_title", lang)
         
-        # Define pattern for tag names in live mode
-        TAG_PATTERN = "Status.ColorSort.Sort1.DefectCount{}.Rate.Current"
+        # Define pattern for tag names in live mode based on selected view mode
+        if counter_mode == "percent":
+            TAG_PATTERN = "Status.ColorSort.Sort1.DefectCount{}.Percentage.Current"
+        else:
+            TAG_PATTERN = "Status.ColorSort.Sort1.DefectCount{}.Rate.Current"
         
         # Define colors for each primary/counter number
         counter_colors = {
@@ -5849,12 +5853,13 @@ def _register_callbacks_impl(app):
          State({"type": "threshold-max-value", "index": ALL}, "value"),
          State("threshold-email-address", "value"),
          State("threshold-email-minutes", "value"),
-         State("threshold-email-enabled", "value")],
+         State("threshold-email-enabled", "value"),
+         State("counter-view-mode", "data")],
         prevent_initial_call=True
     )
     def toggle_threshold_modal(open_clicks, close_clicks, save_clicks, is_open,
                               min_enabled_values, max_enabled_values, min_values, max_values,
-                              email_address, email_minutes, email_enabled):
+                              email_address, email_minutes, email_enabled, mode):
         """Handle opening/closing the threshold settings modal and saving settings"""
         global threshold_settings
         
@@ -5897,6 +5902,7 @@ def _register_callbacks_impl(app):
                 threshold_settings['email_enabled'] = email_enabled
                 threshold_settings['email_address'] = email_address
                 threshold_settings['email_minutes'] = int(email_minutes) if email_minutes is not None else 2
+                threshold_settings['counter_mode'] = mode
                 
                 # Save settings to file
                 save_success = save_threshold_settings(threshold_settings)
@@ -5914,10 +5920,11 @@ def _register_callbacks_impl(app):
     @app.callback(
         Output("threshold-form-container", "children"),
         [Input({"type": "open-threshold", "index": ALL}, "n_clicks"),
-         Input("language-preference-store", "data")],
+         Input("language-preference-store", "data"),
+         Input("counter-view-mode", "data")],
         prevent_initial_call=True,
     )
-    def refresh_threshold_form(open_clicks, lang):
+    def refresh_threshold_form(open_clicks, lang, mode):
         ctx = callback_context
         if not ctx.triggered:
             raise PreventUpdate
@@ -5925,10 +5932,18 @@ def _register_callbacks_impl(app):
         trigger = ctx.triggered[0]["prop_id"]
         if '"type":"open-threshold"' in trigger:
             if any(click is not None for click in open_clicks):
-                return create_threshold_settings_form(lang)
-        if trigger == "language-preference-store.data":
-            return create_threshold_settings_form(lang)
+                return create_threshold_settings_form(lang, mode)
+        if trigger == "language-preference-store.data" or trigger == "counter-view-mode.data":
+            return create_threshold_settings_form(lang, mode)
         raise PreventUpdate
+
+    @app.callback(
+        Output("counter-view-mode", "data"),
+        Input("counter-mode-toggle", "value"),
+        prevent_initial_call=True,
+    )
+    def set_counter_view_mode(value):
+        return value
 
     @app.callback(
         Output("metric-logging-store", "data"),

--- a/tests/test_threshold_display_translation.py
+++ b/tests/test_threshold_display_translation.py
@@ -22,8 +22,8 @@ def test_threshold_form_translations(monkeypatch):
     mod = importlib.import_module(module_name)
     rows_en = mod.create_threshold_settings_form("en")
     rows_es = mod.create_threshold_settings_form("es")
-    assert _get_label_text(rows_en[0]) == "Sensitivity 1:"
-    assert "Sensibilidad" in _get_label_text(rows_es[0])
+    assert _get_label_text(rows_en[1]) == "Sensitivity 1:"
+    assert "Sensibilidad" in _get_label_text(rows_es[1])
     assert "Notificación" in _get_label_text(rows_es[-1])
 
 


### PR DESCRIPTION
## Summary
- add `counter-view-mode` store and selection UI in threshold modal
- support Counts/Percent selection for Section 5_2 chart
- persist mode in threshold settings
- update tests for new UI row
- include percentage OPC tags so live data updates correctly

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68779b2351bc8327baabc36607f967eb