### PR TITLE
Adjust lab test input layout

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2354,7 +2354,7 @@ def connection_controls(lang=_initial_lang):
                     clearable=False,
                     searchable=False,
                     className="small p-0",
-                    style={"min-width": "80px"}
+                    style={"min-width": "60px"}
                 ),
             ], width={"xs":1, "md":1}, className="px-1"),
 
@@ -2372,7 +2372,7 @@ def connection_controls(lang=_initial_lang):
                             placeholder=tr("test_lot_name_placeholder", lang),
                             size="sm",
                             className="me-1",
-                            style={"maxWidth": "150px"}
+                            style={"maxWidth": "200px"}
                         ),
                         dbc.RadioItems(
                             id="lab-start-selector",
@@ -2387,7 +2387,7 @@ def connection_controls(lang=_initial_lang):
                         ),
                     ],
                 ),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":3, "md":3}, className="px-1"),
             
             # Historical Time Slider (keep this)
             dbc.Col([


### PR DESCRIPTION
## Summary
- slim down the mode selector dropdown
- widen the lab test name field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878fc5319dc83278c788547c9f37848