### PR TITLE
Adjust lab test input layout

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2354,7 +2354,7 @@ def connection_controls(lang=_initial_lang):
                     clearable=False,
                     searchable=False,
                     className="small p-0",
-                    style={"min-width": "80px"}
+                    style={"width": "60px", "minWidth": "60px"}
                 ),
             ], width={"xs":1, "md":1}, className="px-1"),
 
@@ -2372,7 +2372,7 @@ def connection_controls(lang=_initial_lang):
                             placeholder=tr("test_lot_name_placeholder", lang),
                             size="sm",
                             className="me-1",
-                            style={"maxWidth": "150px"}
+                            style={"width": "100%", "maxWidth": "500px"}
                         ),
                         dbc.RadioItems(
                             id="lab-start-selector",
@@ -2382,12 +2382,12 @@ def connection_controls(lang=_initial_lang):
                             ],
                             value="feeder",
                             inline=True,
-                            className="small d-inline-flex",
-                            style={"gap": "0.5rem"},
+                            className="small d-inline-flex flex-nowrap",
+                            style={"gap": "0.5rem", "whiteSpace": "nowrap"},
                         ),
                     ],
                 ),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":4, "md":4}, className="px-1"),
             
             # Historical Time Slider (keep this)
             dbc.Col([
@@ -2445,7 +2445,7 @@ def connection_controls(lang=_initial_lang):
                         )
                     ], className="")
                 ], className="text-end"),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":1, "md":1}, className="px-1"),
 
             # Hidden Name field (keep this)
             dbc.Col([
@@ -2455,7 +2455,7 @@ def connection_controls(lang=_initial_lang):
                     type="hidden"
                 ),
             ], width=0, style={"display": "none"}),
-        ], className="g-0 align-items-center"),
+        ], className="gx-2 align-items-center"),
     ], className="py-1 px-2"),
     className="mb-1 mt-0",
     )


### PR DESCRIPTION
## Summary
- slim down the mode selector dropdown more without cutting text
- enlarge the lab test name input
- keep lab start options on a single line
- give columns breathing room

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878fc5319dc83278c788547c9f37848