### PR TITLE
Adjust lab test input layout

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2330,7 +2330,7 @@ def connection_controls(lang=_initial_lang):
                     html.Span(tr("active_machine_label", lang), id="active-machine-label", className="fw-bold small me-1"),
                     html.Span(id="active-machine-display", className="small"),
                 ], className="mt-1"),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":2, "md":2}, className="px-1" ),
             
             # Status (keep this)
             dbc.Col([
@@ -2354,7 +2354,7 @@ def connection_controls(lang=_initial_lang):
                     clearable=False,
                     searchable=False,
                     className="small p-0",
-                    style={"min-width": "80px"}
+                    style={"width": "100px", "minWidth": "100px"}
                 ),
             ], width={"xs":1, "md":1}, className="px-1"),
 
@@ -2362,7 +2362,7 @@ def connection_controls(lang=_initial_lang):
             dbc.Col([
                 html.Div(
                     id="lab-test-controls",
-                    className="d-none",
+                    className="d-none d-flex align-items-center gap-1",
                     children=[
                         dbc.Button(tr("start_test", lang), id="start-test-btn", color="success", size="sm", className="py-0 me-1"),
                         dbc.Button(tr("stop_test", lang), id="stop-test-btn", color="danger", size="sm", className="py-0 me-1"),
@@ -2372,22 +2372,28 @@ def connection_controls(lang=_initial_lang):
                             placeholder=tr("test_lot_name_placeholder", lang),
                             size="sm",
                             className="me-1",
-                            style={"maxWidth": "150px"}
-                        ),
-                        dbc.RadioItems(
-                            id="lab-start-selector",
-                            options=[
-                                {"label": tr("local_start_option", lang), "value": "local"},
-                                {"label": tr("feeder_start_option", lang), "value": "feeder"},
-                            ],
-                            value="feeder",
-                            inline=True,
-                            className="small d-inline-flex",
-                            style={"gap": "0.5rem"},
+                            style={"width": "250px"}
                         ),
                     ],
                 ),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":4, "md":3}, className="px-1"),
+
+            dbc.Col(
+                dbc.RadioItems(
+                    id="lab-start-selector",
+                    options=[
+                        {"label": tr("local_start_option", lang), "value": "local"},
+                        {"label": tr("feeder_start_option", lang), "value": "feeder"},
+                    ],
+                    value="feeder",
+                    inline=True,
+                    className="small d-inline-flex flex-nowrap",
+                    style={"gap": "0.5rem", "whiteSpace": "nowrap", "flexWrap": "nowrap"},
+                ),
+                id="lab-start-selector-col",
+                width={"xs":2, "md":2},
+                className="px-1 d-none",
+            ),
             
             # Historical Time Slider (keep this)
             dbc.Col([
@@ -2414,7 +2420,7 @@ def connection_controls(lang=_initial_lang):
                         style={"whiteSpace": "nowrap", "fontSize": "0.7rem", "marginTop": "-2px"}
                     )
                 ]),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":2, "md":1}, className="px-1"),
             
             # Settings and Export buttons (keep this)
             dbc.Col([
@@ -2445,7 +2451,7 @@ def connection_controls(lang=_initial_lang):
                         )
                     ], className="")
                 ], className="text-end"),
-            ], width={"xs":2, "md":2}, className="px-1"),
+            ], width={"xs":1, "md":1}, className="px-1"),
 
             # Hidden Name field (keep this)
             dbc.Col([
@@ -2455,7 +2461,7 @@ def connection_controls(lang=_initial_lang):
                     type="hidden"
                 ),
             ], width=0, style={"display": "none"}),
-        ], className="g-0 align-items-center"),
+        ], className="gx-2 align-items-center"),
     ], className="py-1 px-2"),
     className="mb-1 mt-0",
     )

--- a/callbacks.py
+++ b/callbacks.py
@@ -5479,12 +5479,14 @@ def _register_callbacks_impl(app):
             return "d-none"  # Hide controls
 
     @app.callback(
-        Output("lab-test-controls", "className"),
+        [Output("lab-test-controls", "className"),
+         Output("lab-start-selector-col", "className")],
         [Input("mode-selector", "value")],
         prevent_initial_call=True,
     )
     def toggle_lab_controls_visibility(mode):
-        return "d-flex" if mode == "lab" else "d-none"
+        cls = "d-flex" if mode == "lab" else "d-none"
+        return cls, cls
 
     @app.callback(
         [Output("start-test-btn", "disabled"),


### PR DESCRIPTION
## Summary
- slim down the mode selector dropdown more without cutting text
- enlarge the lab test name input
- spread lab buttons inline and keep start options from wrapping
- push radio items into their own column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878fc5319dc83278c788547c9f37848