### PR TITLE
Fix lab control layout widths

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2354,8 +2354,7 @@ def connection_controls(lang=_initial_lang):
                     clearable=False,
                     searchable=False,
                     className="small p-0",
-
-                    style={"min-width": "60px"}
+                    style={"width": "100px"}
                 ),
             ], width="auto", className="px-1"),
 
@@ -2373,23 +2372,29 @@ def connection_controls(lang=_initial_lang):
                             placeholder=tr("test_lot_name_placeholder", lang),
                             size="sm",
                             className="me-1",
-
-                            style={"maxWidth": "200px"}
-                        ),
-                        dbc.RadioItems(
-                            id="lab-start-selector",
-                            options=[
-                                {"label": tr("local_start_option", lang), "value": "local"},
-                                {"label": tr("feeder_start_option", lang), "value": "feeder"},
-                            ],
-                            value="feeder",
-                            inline=True,
-                            className="small d-inline-flex flex-nowrap",
-                            style={"gap": "0.5rem", "whiteSpace": "nowrap"},
+                            style={"width": "250px"}
                         ),
                     ],
                 ),
             ], width={"xs":3, "md":3}, className="px-1"),
+
+            # Lab Start Selector Column
+            dbc.Col(
+                dbc.RadioItems(
+                    id="lab-start-selector",
+                    options=[
+                        {"label": tr("local_start_option", lang), "value": "local"},
+                        {"label": tr("feeder_start_option", lang), "value": "feeder"},
+                    ],
+                    value="feeder",
+                    inline=True,
+                    className="small d-inline-flex flex-nowrap",
+                    style={"gap": "0.5rem", "whiteSpace": "nowrap"},
+                ),
+                id="lab-start-selector-col",
+                width={"xs":2, "md":2},
+                className="px-1 d-none",
+            ),
 
             
             # Historical Time Slider (keep this)


### PR DESCRIPTION
## Summary
- enlarge text field for lab tests
- limit mode dropdown width
- move lab start radio buttons to a new column
- keep tests passing

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879270412008327af9c2525123ee7bf