### PR TITLE
Update lab mode counts from live log

### DIFF
--- a/tests/test_load_last_lab_objects.py
+++ b/tests/test_load_last_lab_objects.py
@@ -1,0 +1,22 @@
+import callbacks
+import hourly_data_saving
+import os
+
+def test_load_last_lab_objects(monkeypatch, tmp_path):
+    # Prepare temp lab log
+    export_dir = tmp_path
+    machine_id = 1
+    machine_dir = export_dir / str(machine_id)
+    machine_dir.mkdir(parents=True)
+    log = machine_dir / "Lab_Test_sample.csv"
+    log.write_text(
+        "timestamp,objects_per_min,objects_60M,counter_1\n"
+        "2025-01-01T00:00:00,10,100,0\n"
+        "2025-01-01T00:01:00,20,150,1\n"
+    )
+
+    monkeypatch.setattr(hourly_data_saving, "EXPORT_DIR", str(export_dir))
+    callbacks._lab_totals_cache.clear()
+
+    value = callbacks.load_last_lab_objects(machine_id)
+    assert value == 150


### PR DESCRIPTION
## Summary
- add `load_last_lab_objects` helper to read most recent objects_60M value
- use the new helper in `update_section_1_1` when in lab mode
- test new helper

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795e5615ec832792f2c04a10e0ee10