### PR TITLE
Fix manual lab test stop

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1009,7 +1009,7 @@ def _register_callbacks_impl(app):
             return True
         if stop_time is None:
             return False
-        return (time.time() - stop_time) < 30
+        return (time.time() - abs(stop_time)) < 30
 
     @app.callback(
         [Output("delete-confirmation-modal", "is_open"),
@@ -5585,7 +5585,7 @@ def _register_callbacks_impl(app):
             return True, "secondary", True, "secondary"
 
         # Disable both buttons during the 30s grace period after stopping
-        if running and stop_time and (time.time() - stop_time < 30):
+        if running and stop_time and (time.time() - abs(stop_time) < 30):
             return True, "secondary", True, "secondary"
 
         if running:
@@ -5658,7 +5658,7 @@ def _register_callbacks_impl(app):
             return True
 
         # Check if we should end the test based on the stop time
-        if running and stop_time and (time.time() - stop_time >= 30):
+        if running and stop_time and (time.time() - abs(stop_time) >= 30):
             current_lab_filename = None
             try:
                 refresh_lab_cache(active_machine_id)
@@ -5720,11 +5720,10 @@ def _register_callbacks_impl(app):
         ctx = callback_context
         if ctx.triggered:
             trigger = ctx.triggered[0]["prop_id"].split(".")[0]
-            if start_mode != "feeder":
-                if trigger == "stop-test-btn":
-                    return time.time()
-                if trigger == "start-test-btn":
-                    return None
+            if trigger == "stop-test-btn":
+                return -time.time()
+            if trigger == "start-test-btn":
+                return None
 
         if not running:
             return dash.no_update
@@ -5745,7 +5744,7 @@ def _register_callbacks_impl(app):
                 break
 
         if any_running:
-            if stop_time is not None:
+            if stop_time is not None and stop_time >= 0:
                 return None
         else:
             if start_mode == "feeder" and stop_time is None:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -303,3 +303,21 @@ def test_lab_restart_clears_stop_time(monkeypatch):
     monkeypatch.setattr(callbacks, "callback_context", DummyCtx("status-update-interval.n_intervals"))
     res = func.__wrapped__(None, None, 1, True, 100.0, {"mode": "lab"}, {"machine_id": 1}, "feeder")
     assert res is None
+
+
+def test_manual_stop_sets_negative_time(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+
+    func = app.callback_map["lab-test-stop-time.data"]["callback"]
+
+    class DummyCtx:
+        def __init__(self, prop_id):
+            self.triggered = [{"prop_id": prop_id}]
+
+    monkeypatch.setattr(callbacks, "callback_context", DummyCtx("stop-test-btn.n_clicks"))
+    monkeypatch.setattr(callbacks.time, "time", lambda: 456.0)
+
+    res = func.__wrapped__(None, 1, 0, True, None, {"mode": "lab"}, {"machine_id": 1}, "feeder")
+    assert res == -456.0


### PR DESCRIPTION
## Summary
- ensure stop button sets stop time regardless of start mode
- track manual stops with negative timestamp so the grace period isn't cancelled when feeders continue running
- update tests

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a43a0fafc8327b284dc61bf674a43