### PR TITLE
Reduce default log verbosity

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -89,9 +89,9 @@ except Exception:  # pragma: no cover - optional dependency
 logging.getLogger('opcua').setLevel(logging.WARNING)  # Turn off OPC UA debug logs
 logging.getLogger('opcua.client.ua_client').setLevel(logging.WARNING)
 logging.getLogger('opcua.uaprotocol').setLevel(logging.WARNING)
-log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+log_level = os.environ.get("LOG_LEVEL", "WARNING").upper()
 logging.basicConfig(
-    level=getattr(logging, log_level, logging.INFO),
+    level=getattr(logging, log_level, logging.WARNING),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ python3 EnpresorOPCDataViewBeforeRestructureLegacy.py
 ```
 The script prints the local and network URLs for accessing the interface. Optionally use `--open-browser` to automatically open your web browser and `--debug` for verbose output.
 
+To reduce log noise, set the `LOG_LEVEL` environment variable. The default level is `WARNING` so informational logs are suppressed unless `LOG_LEVEL` is overridden:
+
+```bash
+export LOG_LEVEL=INFO  # show additional details
+python3 EnpresorOPCDataViewBeforeRestructureLegacy.py
+```
+
 ### Simulating Lab Mode
 
 The `scripts/lab_mode_sim.py` helper reads a CSV log and prints the values that

--- a/generate_report.py
+++ b/generate_report.py
@@ -323,9 +323,9 @@ def last_value_scaled(series, scale=1.0):
 
 from hourly_data_saving import EXPORT_DIR as METRIC_EXPORT_DIR, get_historical_data
 
-log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+log_level = os.environ.get("LOG_LEVEL", "WARNING").upper()
 logging.basicConfig(
-    level=getattr(logging, log_level, logging.INFO),
+    level=getattr(logging, log_level, logging.WARNING),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- lower default log level to WARNING in dashboard and report scripts
- document using LOG_LEVEL to control verbosity

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687aa164b2ac83278f6fe3fbd84ec3ed