### PR TITLE
Honor IsAssigned in lab stats

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -553,6 +553,7 @@ def draw_global_summary(
         fp = os.path.join(csv_parent_dir, m, 'last_24h_metrics.csv')
         if os.path.isfile(fp):
             df = df_processor.safe_read_csv(fp)
+            settings_data = load_machine_settings(csv_parent_dir, m)
             if 'capacity' in df.columns:
                 stats = calculate_total_capacity_from_csv_rates(
                     df['capacity'],
@@ -579,8 +580,18 @@ def draw_global_summary(
                 machine_removed = 0
                 for i in range(1, 13):
                     col = next((c for c in df.columns if c.lower() == f'counter_{i}'), None)
-                    if col:
-                        machine_removed += last_value_scaled(df[col], 60)
+                    if not col:
+                        continue
+
+                    assigned_val = _lookup_setting(
+                        settings_data,
+                        f"Settings.ColorSort.Primary{i}.IsAssigned",
+                        True,
+                    )
+                    if not _bool_from_setting(assigned_val):
+                        continue
+
+                    machine_removed += last_value_scaled(df[col], 60)
 
                 total_objects += machine_objects
                 total_removed += machine_removed
@@ -889,17 +900,26 @@ def calculate_global_max_firing_average(csv_parent_dir, machines=None, *, is_lab
         if os.path.isfile(fp):
             try:
                 df = df_processor.safe_read_csv(fp)
+                settings_data = load_machine_settings(csv_parent_dir, machine)
                 ts = df.get('timestamp') if is_lab_mode else None
                 # Find counter values for this machine
                 for i in range(1, 13):
                     col_name = next((c for c in df.columns if c.lower() == f'counter_{i}'), None)
-                    if col_name and col_name in df.columns:
-                        if is_lab_mode:
-                            val = last_value_scaled(df[col_name], 60)
-                        else:
-                            val = df[col_name].mean()
-                        if not pd.isna(val):
-                            global_max = max(global_max, val)
+                    if not col_name or col_name not in df.columns:
+                        continue
+                    if is_lab_mode:
+                        assigned_val = _lookup_setting(
+                            settings_data,
+                            f"Settings.ColorSort.Primary{i}.IsAssigned",
+                            True,
+                        )
+                        if not _bool_from_setting(assigned_val):
+                            continue
+                        val = last_value_scaled(df[col_name], 60)
+                    else:
+                        val = df[col_name].mean()
+                    if not pd.isna(val):
+                        global_max = max(global_max, val)
             except Exception as e:
                 logger.error(f"Error calculating max for machine {machine}: {e}")
     
@@ -913,6 +933,10 @@ def enhanced_calculate_stats_for_machine(csv_parent_dir, machine, *, is_lab_mode
     :func:`df_processor.safe_read_csv` and computes totals for common metrics.
     ``df_processor.process_with_cleanup`` is used when running the calculation
     helpers to ensure any temporary pandas objects are cleaned up.
+
+    When running in lab mode, counters for sensitivities whose
+    ``IsAssigned`` flag is false are ignored so that inactive sensitivities do
+    not contribute to the totals.
     """
     fp = os.path.join(csv_parent_dir, str(machine), "last_24h_metrics.csv")
     if not os.path.isfile(fp):
@@ -939,6 +963,7 @@ def enhanced_calculate_stats_for_machine(csv_parent_dir, machine, *, is_lab_mode
         }
 
     ts = df.get("timestamp") if is_lab_mode else None
+    settings_data = load_machine_settings(csv_parent_dir, machine)
 
     def calc_cap(series):
         return calculate_total_capacity_from_csv_rates(series, timestamps=ts, is_lab_mode=is_lab_mode)
@@ -967,8 +992,19 @@ def enhanced_calculate_stats_for_machine(csv_parent_dir, machine, *, is_lab_mode
     removed_total = 0
     for i in range(1, 13):
         col = next((c for c in df.columns if c.lower() == f"counter_{i}"), None)
-        if col:
-            removed_total += df_processor.process_with_cleanup(df[col], calc_obj)["total_objects"]
+        if not col:
+            continue
+
+        if is_lab_mode:
+            assigned_val = _lookup_setting(
+                settings_data,
+                f"Settings.ColorSort.Primary{i}.IsAssigned",
+                True,
+            )
+            if not _bool_from_setting(assigned_val):
+                continue
+
+        removed_total += df_processor.process_with_cleanup(df[col], calc_obj)["total_objects"]
 
     running_mins = df.get("running", pd.Series(dtype=float)).sum() if "running" in df.columns else 0
     stopped_mins = df.get("stopped", pd.Series(dtype=float)).sum() if "stopped" in df.columns else 0
@@ -1609,6 +1645,22 @@ def draw_machine_sections(
     stop_col = next((c for c in df.columns if c.lower()=='stopped'), None)
     a_val = df[ac_col].sum() if ac_col else 0
     r_val = df[rj_col].sum() if rj_col else 0
+
+    # In lab mode use the counters for rejects
+    if is_lab_mode:
+        r_val = 0
+        for i in range(1, 13):
+            col = next((c for c in df.columns if c.lower() == f"counter_{i}"), None)
+            if not col:
+                continue
+            assigned_val = _lookup_setting(
+                settings_data,
+                f"Settings.ColorSort.Primary{i}.IsAssigned",
+                True,
+            )
+            if not _bool_from_setting(assigned_val):
+                continue
+            r_val += df[col].sum()
     run_total = df[run_col].sum() if run_col else 0
     stop_total = df[stop_col].sum() if stop_col else 0
     
@@ -1711,13 +1763,23 @@ def draw_machine_sections(
     counter_values = []
     for i in range(1, 13):
         col_name = next((c for c in df.columns if c.lower() == f'counter_{i}'), None)
-        if col_name and col_name in df.columns:
-            if is_lab_mode:
-                val = last_value_scaled(df[col_name], 60)
-            else:
-                val = df[col_name].mean()
-            if not pd.isna(val):
-                counter_values.append((f"S{i}", val))
+        if not col_name or col_name not in df.columns:
+            continue
+
+        if is_lab_mode:
+            assigned_val = _lookup_setting(
+                settings_data,
+                f"Settings.ColorSort.Primary{i}.IsAssigned",
+                True,
+            )
+            if not _bool_from_setting(assigned_val):
+                continue
+            val = last_value_scaled(df[col_name], 60)
+        else:
+            val = df[col_name].mean()
+
+        if not pd.isna(val):
+            counter_values.append((f"S{i}", val))
 
     if counter_values:
         # UPDATED: Reduced width by 5%, increased height by 5%
@@ -1798,8 +1860,19 @@ def draw_machine_sections(
     machine_rem = 0
     for i in range(1, 13):
         col = next((c for c in df.columns if c.lower() == f'counter_{i}'), None)
-        if col:
-            machine_rem += last_value_scaled(df[col], 60)
+        if not col:
+            continue
+
+        if is_lab_mode:
+            assigned_val = _lookup_setting(
+                settings_data,
+                f"Settings.ColorSort.Primary{i}.IsAssigned",
+                True,
+            )
+            if not _bool_from_setting(assigned_val):
+                continue
+
+        machine_rem += last_value_scaled(df[col], 60)
 
     machine_accepts = 0
     machine_rejects = 0

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,6 +1,7 @@
 
 import json
 from pathlib import Path
+import pytest
 
 import generate_report
 
@@ -150,6 +151,34 @@ def test_position_text_from_axis_wave_lab_mode():
         settings = {"Settings": {"ColorSort": {"Primary1": {"TypeId": 1, **waves}}}}
         generate_report.draw_sensitivity_grid(c, 0, 0, 100, 20, settings, 1, is_lab_mode=True)
         assert expected in c.texts
+
+
+def test_enhanced_calculate_stats_respects_isassigned(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir()
+    csv = machine_dir / "last_24h_metrics.csv"
+    csv.write_text(
+        "timestamp,counter_1,counter_2\n"
+        "2025-01-01T00:00:00,1,2\n"
+        "2025-01-01T00:01:00,1,2\n"
+    )
+
+    settings = {
+        "Settings": {
+            "ColorSort": {
+                "Primary1": {"IsAssigned": "TRUE"},
+                "Primary2": {"IsAssigned": "FALSE"},
+            }
+        }
+    }
+
+    json.dump(settings, open(machine_dir / "settings.json", "w"))
+
+    stats = generate_report.enhanced_calculate_stats_for_machine(
+        tmp_path, "1", is_lab_mode=True
+    )
+
+    assert stats["removed"] == pytest.approx(generate_report.LAB_OBJECT_SCALE_FACTOR)
 
 
 


### PR DESCRIPTION
## Summary
- skip unassigned sensitivities when summing counts in lab mode
- document IsAssigned behavior in `enhanced_calculate_stats_for_machine`
- compute pie chart rejects from active counters

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a7367562c8327aecf40250b84f042