### PR TITLE
Honor IsAssigned in lab stats

### DIFF
--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,6 +1,7 @@
 
 import json
 from pathlib import Path
+import pytest
 
 import generate_report
 
@@ -150,6 +151,74 @@ def test_position_text_from_axis_wave_lab_mode():
         settings = {"Settings": {"ColorSort": {"Primary1": {"TypeId": 1, **waves}}}}
         generate_report.draw_sensitivity_grid(c, 0, 0, 100, 20, settings, 1, is_lab_mode=True)
         assert expected in c.texts
+
+
+def test_enhanced_calculate_stats_respects_isassigned(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir()
+    csv = machine_dir / "last_24h_metrics.csv"
+    csv.write_text(
+        "timestamp,counter_1,counter_2\n"
+        "2025-01-01T00:00:00,1,2\n"
+        "2025-01-01T00:01:00,1,2\n"
+    )
+
+    settings = {
+        "Settings": {
+            "ColorSort": {
+                "Primary1": {"IsAssigned": "TRUE"},
+                "Primary2": {"IsAssigned": "FALSE"},
+            }
+        }
+    }
+
+    json.dump(settings, open(machine_dir / "settings.json", "w"))
+
+    stats = generate_report.enhanced_calculate_stats_for_machine(
+        tmp_path, "1", is_lab_mode=True
+    )
+
+    assert stats["removed"] == pytest.approx(generate_report.LAB_OBJECT_SCALE_FACTOR)
+
+
+def test_machine_pie_reject_percent_uses_objects(tmp_path):
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir()
+    csv = machine_dir / "last_24h_metrics.csv"
+    csv.write_text(
+        "timestamp,objects_per_min,counter_1\n"
+        "2025-01-01T00:00:00,10,1\n"
+        "2025-01-01T00:01:00,10,1\n"
+    )
+
+    settings = {"Settings": {"ColorSort": {"Primary1": {"IsAssigned": "TRUE"}}}}
+    json.dump(settings, open(machine_dir / "settings.json", "w"))
+
+    class DummyCanvas:
+        def __init__(self):
+            self.texts = []
+            self._pagesize = (612.0, 792.0)
+
+        def __getattr__(self, name):
+            if name in ("drawString", "drawCentredString"):
+                return lambda x, y, text: self.texts.append(text)
+            if name == "stringWidth":
+                return lambda text, font, size: len(text)
+            return lambda *a, **k: None
+
+    c = DummyCanvas()
+    generate_report.draw_machine_sections(
+        c,
+        tmp_path,
+        "1",
+        0,
+        200,
+        200,
+        100,
+        is_lab_mode=True,
+    )
+
+    assert any("10.0%" in t for t in c.texts)
 
 
 


### PR DESCRIPTION
## Summary
- skip unassigned sensitivities when summing counts in lab mode
- document IsAssigned behavior in `enhanced_calculate_stats_for_machine`
- compute pie chart rejects from active counters
- calculate reject percentage as removed/processed when in lab mode
- add regression test for pie chart reject percentage

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a7367562c8327aecf40250b84f042