### PR TITLE
Fix lab pie chart percentages

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1773,13 +1773,12 @@ def draw_machine_sections(
         renderPDF.draw(d_pie, c, -psz/2, -psz/2)
         c.restoreState()
         
-        # Add labels with smaller fonts
-        total_pie = machine_objs
+        # Add labels with smaller fonts using the same values as the pie slices
+        total_pie = a_val + r_val
         if total_pie > 0:
-            accept_obj = machine_objs - machine_rem
-            reject_obj = machine_rem
-            percentages = [(accept_obj/total_pie)*100, (reject_obj/total_pie)*100]
-            angles = [180+-59 + (360*((reject_obj/total_pie)*100)/2/100), -59 + (360*((reject_obj/total_pie)*100)/2/100)]
+            percentages = [(a_val/total_pie)*100, (r_val/total_pie)*100]
+            reject_ratio = r_val / total_pie
+            angles = [180 + -59 + (360 * reject_ratio)/2, -59 + (360 * reject_ratio)/2]
             labels = [tr('accepts', lang), tr('rejects', lang)]
             
             for i, (label, pct, angle) in enumerate(zip(labels, percentages, angles)):


### PR DESCRIPTION
## Summary
- ensure per-machine pie chart labels use same values as pie slices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5cf86fd483279ff528c372fe0a73