### PR TITLE
Align sensitivity borders with bar colors

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -34,6 +34,22 @@ LAB_WEIGHT_MULTIPLIER = 1 / 1800
 
 from i18n import tr
 
+# Colors used for bar charts and sensitivity section borders
+BAR_COLORS = [
+    colors.red,
+    colors.blue,
+    colors.green,
+    colors.orange,
+    colors.purple,
+    colors.brown,
+    colors.pink,
+    colors.gray,
+    colors.cyan,
+    colors.magenta,
+    colors.yellow,
+    colors.black,
+]
+
 
 def _lookup_setting(data: dict, dotted_key: str, default="N/A"):
     """Return a nested setting value using dotted notation.
@@ -1221,6 +1237,7 @@ def draw_sensitivity_grid(
     counter_value=None,
     lang="en",
     is_lab_mode=False,
+    border_color=colors.black,
 ):
     """Draw a grid of settings for a single sensitivity.
 
@@ -1475,6 +1492,12 @@ def draw_sensitivity_grid(
     finally:
         # Always restore state even if there was an error
         try:
+            # Draw colored border around entire section
+            c.setStrokeColor(border_color)
+            c.rect(x0, y0, total_w, section_h, fill=0, stroke=1)
+        except Exception:
+            pass
+        try:
             c.restoreState()
         except:
             # If restoreState fails, there's not much we can do
@@ -1495,6 +1518,7 @@ def draw_sensitivity_sections(
     width=None,
     height=None,
     lab_test_name: str | None = None,
+    bar_colors=BAR_COLORS,
 ):
     """Draw grids for all active sensitivities and return new y position."""
     spacing = 10
@@ -1543,6 +1567,7 @@ def draw_sensitivity_sections(
             counter_value=counter_values.get(i) if counter_values else None,
             lang=lang,
             is_lab_mode=is_lab_mode,
+            border_color=bar_colors[(i - 1) % len(bar_colors)] if bar_colors else colors.black,
         )
         current_y = y_grid - spacing
 
@@ -1875,9 +1900,7 @@ def draw_machine_sections(
         # Use global max if provided, otherwise use local max
         max_val = global_max_firing if global_max_firing and global_max_firing > 0 else max(val for _, val in counter_values)
         
-        bar_colors = [colors.red, colors.blue, colors.green, colors.orange, 
-                    colors.purple, colors.brown, colors.pink, colors.gray,
-                    colors.cyan, colors.magenta, colors.yellow, colors.black]
+        bar_colors = BAR_COLORS
         
         for i, (counter_name, val) in enumerate(counter_values):
             bar_x = chart_x + i * bar_spacing + (bar_spacing - bar_width)/2
@@ -2045,6 +2068,7 @@ def draw_machine_sections(
         width=width,
         height=height,
         lab_test_name=lab_test_name,
+        bar_colors=BAR_COLORS,
     )
 
     # Return the Y position where the next content should start

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -61,7 +61,7 @@ def test_draw_sensitivity_sections_only_active(monkeypatch):
     }
 
     end_y = generate_report.draw_sensitivity_sections(
-        None, 0, 100, 50, 10, settings
+        None, 0, 100, 50, 10, settings, bar_colors=generate_report.BAR_COLORS
     )
 
     assert calls == [1, 3]
@@ -106,7 +106,7 @@ def test_primary7_typeid_label_lab_mode():
         c = DummyCanvas()
         settings = {"Settings": {"ColorSort": {"Primary7": {"TypeId": value}}}}
         generate_report.draw_sensitivity_grid(
-            c, 0, 0, 100, 20, settings, 7, is_lab_mode=True
+            c, 0, 0, 100, 20, settings, 7, is_lab_mode=True, border_color=generate_report.BAR_COLORS[6]
         )
         assert expected in c.texts
 
@@ -149,7 +149,9 @@ def test_position_text_from_axis_wave_lab_mode():
     for waves, expected in cases:
         c = DummyCanvas()
         settings = {"Settings": {"ColorSort": {"Primary1": {"TypeId": 1, **waves}}}}
-        generate_report.draw_sensitivity_grid(c, 0, 0, 100, 20, settings, 1, is_lab_mode=True)
+        generate_report.draw_sensitivity_grid(
+            c, 0, 0, 100, 20, settings, 1, is_lab_mode=True, border_color=generate_report.BAR_COLORS[0]
+        )
         assert expected in c.texts
 
 def test_enhanced_calculate_stats_respects_isassigned(tmp_path):


### PR DESCRIPTION
## Summary
- add `BAR_COLORS` constant shared between bar chart and sensitivity grids
- color sensitivity section borders using matching bar colors
- adjust report drawing helpers and unit tests

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6a7efb148327a7301f575fbe3943