### PR TITLE
Add counter trend graph to machine report

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1717,8 +1717,9 @@ def draw_machine_sections(
     
     # Height allocation optimized for 2 machines
     pie_height = available_height * 0.75      # 35% for pie chart
-    bar_height = available_height * 0.75      # 35% for bar chart  
+    bar_height = available_height * 0.75      # 35% for bar chart
     counts_height = available_height * 0.30   # 25% for counts (REDUCED!)
+    trend_height = counts_height              # Trend graph same height as counts
     spacing = 1  # Reduced spacing
     
     current_y = y_start
@@ -1999,8 +2000,81 @@ def draw_machine_sections(
         c.setFillColor(colors.gray)
         c.drawCentredString(x0 + w_left + w_right/2, y_pie + bar_height/2, tr('no_counter_data', lang))
     
-    # Section 3: Machine counts (full width) - SIGNIFICANTLY REDUCED HEIGHT
-    y_counts = y_pie - counts_height - spacing
+    # Section 3: Counter trend graph (full width)
+    y_trend = y_pie - trend_height - spacing
+
+    # Build counter trend data
+    all_t = []
+    series = []
+    max_trend_val = 0
+    base_time = None
+
+    if 'timestamp' in df.columns:
+        time_vals = pd.to_datetime(df['timestamp'], errors='coerce')
+        for idx in range(1, 13):
+            col_name = next((c for c in df.columns if c.lower() == f'counter_{idx}'), None)
+            if not col_name:
+                continue
+            vals = pd.to_numeric(df[col_name], errors='coerce')
+            valid = (~time_vals.isna()) & (~vals.isna())
+            if not valid.any():
+                continue
+            times = time_vals[valid]
+            if base_time is None:
+                base_time = times.min()
+            else:
+                base_time = min(base_time, times.min())
+            pts = [((t - base_time).total_seconds() / 3600.0, float(v)) for t, v in zip(times, vals[valid])]
+            series.append(pts)
+            all_t.extend(times)
+            max_trend_val = max(max_trend_val, vals[valid].max())
+
+    c.setStrokeColor(colors.black)
+    c.rect(x0, y_trend, total_w, trend_height)
+    c.setFont(FONT_BOLD, 8)
+    c.setFillColor(colors.black)
+    c.drawCentredString(x0 + total_w/2, y_trend + trend_height - 10, tr('counter_values_trend_title', lang))
+
+    if series:
+        pad = 6
+        bw, bh = total_w - 2*pad, trend_height - 2*pad - 12
+        tw, th = bw * 0.9, bh * 0.8
+        gx = x0 + pad + (bw - tw)/2
+        gy = y_trend + pad + 12 + (bh - th)/2
+
+        d_trend = Drawing(tw, th)
+        lp = LinePlot()
+        lp.x = lp.y = 0
+        lp.width = tw
+        lp.height = th
+        lp.data = series
+        for i in range(len(series)):
+            lp.lines[i].strokeColor = BAR_COLORS[i % len(BAR_COLORS)]
+            lp.lines[i].strokeWidth = 1.5
+
+        xs = [x for pts in series for x, _ in pts]
+        if xs:
+            lp.xValueAxis.valueMin = min(xs)
+            lp.xValueAxis.valueMax = max(xs)
+            step = (max(xs) - min(xs)) / 4 if max(xs) > min(xs) else 1
+            lp.xValueAxis.valueSteps = [min(xs) + j * step for j in range(5)]
+            if base_time is not None:
+                lp.xValueAxis.labelTextFormat = lambda v: (base_time + timedelta(hours=v)).strftime('%H:%M')
+                lp.xValueAxis.labels.angle = 45
+                lp.xValueAxis.labels.boxAnchor = 'n'
+
+        lp.yValueAxis.valueMin = 0
+        lp.yValueAxis.valueMax = max_trend_val * 1.1 if max_trend_val else 1
+        lp.yValueAxis.valueSteps = None
+        d_trend.add(lp)
+        renderPDF.draw(d_trend, c, gx, gy)
+    else:
+        c.setFont(FONT_DEFAULT, 8)
+        c.setFillColor(colors.gray)
+        c.drawCentredString(x0 + total_w/2, y_trend + trend_height/2, tr('no_counter_data', lang))
+
+    # Section 4: Machine counts (full width) - SIGNIFICANTLY REDUCED HEIGHT
+    y_counts = y_trend - counts_height - spacing
     
    
     # Calculate machine totals


### PR DESCRIPTION
## Summary
- display a trend graph for `counter_X` values for each machine
- use the same color scheme as the bar chart
- position the graph between the pie chart and machine counts sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9740a2c883279b959a7ffa5a1bd7