### PR TITLE
Add auto-set threshold feature

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -1318,17 +1318,16 @@ def create_threshold_settings_form(lang=None, mode=None):
     for i in range(1, 13):
         settings = threshold_settings[i]
 
-        form_rows.append(
-            dbc.Row([
-                # Counter label
-                dbc.Col(
-                    html.Div(
-                        f"{tr('sensitivity_label', lang)} {i}:",
-                        className="fw-bold",
-                        style={"color": counter_colors.get(i, "black")},
-                    ),
-                    width=2,
+        row_children = [
+            # Counter label
+            dbc.Col(
+                html.Div(
+                    f"{tr('sensitivity_label', lang)} {i}:",
+                    className="fw-bold",
+                    style={"color": counter_colors.get(i, "black")},
                 ),
+                width=2,
+            ),
                                                 
                 # Min Value Input
                 dbc.Col(
@@ -1351,11 +1350,11 @@ def create_threshold_settings_form(lang=None, mode=None):
                         label="Min",
                         value=settings['min_enabled'],
                         className="medium"
-                    ),
-                    width=2
                 ),
+                width=2
+            ),
 
-                                
+
                 # Max Value Input
                 dbc.Col(
                     dbc.Input(
@@ -1377,11 +1376,40 @@ def create_threshold_settings_form(lang=None, mode=None):
                         label="Max",
                         value=settings['max_enabled'],
                         className="medium"
-                    ),
-                    width=2
                 ),
+                width=2
+            ),
+        ]
 
-            ], className="mb-2")
+        if i == 1:
+            row_children.extend([
+                # Tolerance input
+                dbc.Col(
+                    dbc.Input(
+                        id="auto-set-percent",
+                        type="number",
+                        min=1,
+                        max=50,
+                        step=1,
+                        value=20,
+                        size="sm",
+                    ),
+                    width=1,
+                ),
+                # Auto set button
+                dbc.Col(
+                    dbc.Button(
+                        "Auto Set",
+                        id="auto-set-button",
+                        color="secondary",
+                        size="sm",
+                    ),
+                    width="auto",
+                ),
+            ])
+
+        form_rows.append(
+            dbc.Row(row_children, className="mb-2")
         )
     
     # Add email notifications with email and minutes inputs

--- a/callbacks.py
+++ b/callbacks.py
@@ -6069,6 +6069,35 @@ def _register_callbacks_impl(app):
         raise PreventUpdate
 
     @app.callback(
+        [Output({"type": "threshold-min-value", "index": ALL}, "value"),
+         Output({"type": "threshold-max-value", "index": ALL}, "value")],
+        Input("auto-set-button", "n_clicks"),
+        State("auto-set-percent", "value"),
+        prevent_initial_call=True,
+    )
+    def auto_set_thresholds(n_clicks, percent):
+        if not n_clicks:
+            raise PreventUpdate
+
+        tolerance = (percent or 20) / 100.0
+        global previous_counter_values, threshold_settings
+
+        new_mins = []
+        new_maxs = []
+        for i, value in enumerate(previous_counter_values):
+            min_val = round(value * (1 - tolerance), 2)
+            max_val = round(value * (1 + tolerance), 2)
+            new_mins.append(min_val)
+            new_maxs.append(max_val)
+
+            counter_num = i + 1
+            if counter_num in threshold_settings:
+                threshold_settings[counter_num]['min_value'] = min_val
+                threshold_settings[counter_num]['max_value'] = max_val
+
+        return new_mins, new_maxs
+
+    @app.callback(
         Output("counter-view-mode", "data"),
         Input("counter-mode-toggle", "value"),
         prevent_initial_call=True,


### PR DESCRIPTION
## Summary
- add numeric tolerance input and Auto Set button in threshold form
- implement callback to auto-populate threshold ranges based on current counter values

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fae60ee048327a6b7e1f708a6f488