### PR TITLE
Fix threshold view mode switch

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -6103,6 +6103,11 @@ def _register_callbacks_impl(app):
         prevent_initial_call=True,
     )
     def set_counter_view_mode(value):
+        """Reset cached counter values when switching view modes."""
+        global previous_counter_values, threshold_settings
+        previous_counter_values = [0] * 12
+        if isinstance(threshold_settings, dict):
+            threshold_settings["counter_mode"] = value
         return value
 
     @app.callback(

--- a/tests/test_counter_view_mode.py
+++ b/tests/test_counter_view_mode.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+
+
+def test_set_counter_view_mode_resets_previous_values(monkeypatch):
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["counter-view-mode.data"]["callback"]
+
+    callbacks.previous_counter_values = list(range(1, 13))
+    callbacks.threshold_settings = {i: {} for i in range(1, 13)}
+    callbacks.threshold_settings["counter_mode"] = "counts"
+
+    result = func.__wrapped__("percent")
+
+    assert callbacks.previous_counter_values == [0] * 12
+    assert callbacks.threshold_settings["counter_mode"] == "percent"
+    assert result == "percent"


### PR DESCRIPTION
## Summary
- reset cached counter values when switching between count and percent views
- test that switching modes resets cached counters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbd5ec31c8327ae528dd5a4132ab3