### PR TITLE
Fix auto-set thresholds for percent view

### DIFF
--- a/tests/test_alarm_mode.py
+++ b/tests/test_alarm_mode.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+
+# Skip if dash is not installed
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+
+
+def test_update_alarms_uses_display_mode(monkeypatch):
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["alarm-data.data"]["callback"]
+
+    callbacks.previous_counter_values = [10] * 12
+    callbacks.threshold_violation_state = {
+        i: {"is_violating": False, "violation_start_time": None, "email_sent": False}
+        for i in range(1, 13)
+    }
+    callbacks.threshold_settings = {
+        i: {"min_enabled": True, "max_enabled": True, "min_value": 8.1, "max_value": 8.5}
+        for i in range(1, 13)
+    }
+    callbacks.threshold_settings["counter_mode"] = "percent"
+    callbacks.threshold_settings["email_enabled"] = False
+
+    result = func.__wrapped__(0, {})
+
+    assert result["alarms"] == []
+

--- a/tests/test_auto_set_thresholds.py
+++ b/tests/test_auto_set_thresholds.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+
+
+def _get_auto_set_func(app):
+    for meta in app.callback_map.values():
+        cb = meta.get("callback")
+        if cb and getattr(cb, "__name__", "") == "auto_set_thresholds":
+            return cb
+    raise AssertionError("auto_set_thresholds callback not found")
+
+
+def test_auto_set_thresholds_respects_mode(monkeypatch):
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = _get_auto_set_func(app)
+
+    callbacks.previous_counter_values = [10] * 12
+    callbacks.threshold_settings = {i: {} for i in range(1, 13)}
+
+    mins, maxs = func.__wrapped__(1, 20, "counts")
+    assert mins[0] == 8.0
+    assert maxs[0] == 12.0
+    assert callbacks.threshold_settings[1]["min_value"] == 8.0
+    assert callbacks.threshold_settings[1]["max_value"] == 12.0
+
+    callbacks.previous_counter_values = [10] * 12
+    callbacks.threshold_settings = {i: {} for i in range(1, 13)}
+
+    mins_p, maxs_p = func.__wrapped__(1, 20, "percent")
+    val = 100 / 12
+    assert mins_p[0] == pytest.approx(round(val * 0.8, 2))
+    assert maxs_p[0] == pytest.approx(round(val * 1.2, 2))
+    assert callbacks.threshold_settings[1]["min_value"] == pytest.approx(round(val * 0.8, 2))
+    assert callbacks.threshold_settings[1]["max_value"] == pytest.approx(round(val * 1.2, 2))

--- a/tests/test_counter_view_mode.py
+++ b/tests/test_counter_view_mode.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+dash = pytest.importorskip("dash")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+
+
+def test_set_counter_view_mode_updates_setting(monkeypatch):
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    func = app.callback_map["counter-view-mode.data"]["callback"]
+
+    original_values = list(range(1, 13))
+    callbacks.previous_counter_values = original_values.copy()
+    callbacks.threshold_settings = {i: {} for i in range(1, 13)}
+    callbacks.threshold_settings["counter_mode"] = "counts"
+
+    result = func.__wrapped__("percent")
+
+    assert callbacks.previous_counter_values == original_values
+    assert callbacks.threshold_settings["counter_mode"] == "percent"
+    assert result == "percent"


### PR DESCRIPTION
## Summary
- use display mode when computing auto-set thresholds
- add regression test for new auto-set behavior
- alarm checks convert counts to percent when percent mode is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbd5ec31c8327ae528dd5a4132ab3