### PR TITLE
Add lab test debug prints

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -23,6 +23,7 @@ except ImportError:  # Python 3.12+ where distutils is removed
             return 0
         raise ValueError(f"invalid truth value {val!r}")
 from threading import Thread
+import threading
 from datetime import datetime, timedelta
 import csv
 import io
@@ -1201,6 +1202,7 @@ def run_async(coro):
 def pause_update_thread():
     """Stop the background update thread if running."""
     if app_state.update_thread and app_state.update_thread.is_alive():
+        print("[LAB TEST] Pausing update thread", app_state.update_thread)
         app_state.thread_stop_flag = True
         app_state.update_thread.join(timeout=5)
 
@@ -1208,6 +1210,7 @@ def pause_update_thread():
 def resume_update_thread():
     """Restart the background update thread if it is not running."""
     if app_state.update_thread is None or not app_state.update_thread.is_alive():
+        print("[LAB TEST] Resuming update thread")
         app_state.thread_stop_flag = False
         app_state.update_thread = Thread(target=opc_update_thread)
         app_state.update_thread.daemon = True
@@ -1221,6 +1224,7 @@ def resume_update_thread():
 def pause_background_processes():
     """Pause non-essential background threads for lab mode."""
     global pause_reconnection
+    print("[LAB TEST] pause_background_processes called - active threads:", [t.name for t in threading.enumerate()])
     pause_reconnection = True
     app_state_manager.set_paused(True)
 
@@ -1230,6 +1234,7 @@ def resume_background_processes():
     global pause_reconnection
     pause_reconnection = False
     app_state_manager.set_paused(False)
+    print("[LAB TEST] resume_background_processes called - active threads:", [t.name for t in threading.enumerate()])
 
 # Connect to OPC UA server
 async def connect_to_server(server_url, server_name=None):

--- a/callbacks.py
+++ b/callbacks.py
@@ -17,6 +17,7 @@ import tempfile
 import time
 import csv
 import re
+import threading
 import hourly_data_saving
 import autoconnect
 import image_manager as img_utils
@@ -942,6 +943,8 @@ def _register_callbacks_impl(app):
         if not n_clicks:
             raise PreventUpdate
 
+        print("[LAB TEST] Generate report button clicked")
+
         export_dir = generate_report.METRIC_EXPORT_DIR
         lang = lang_store or load_language_preference()
         machines = None
@@ -987,6 +990,7 @@ def _register_callbacks_impl(app):
             is_lab_mode = False  # Set to False for regular mode
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            print("[LAB TEST] Report generation started")
             generate_report.build_report(
                 data,
                 tmp.name,
@@ -999,6 +1003,8 @@ def _register_callbacks_impl(app):
             )
             with open(tmp.name, "rb") as f:
                 pdf_bytes = f.read()
+
+        print("[LAB TEST] Report generation completed")
 
         # FIXED: Complete the truncated temp directory cleanup
         if temp_dir:  # This was the truncated line: "if temp"
@@ -5669,6 +5675,8 @@ def _register_callbacks_impl(app):
             trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if start_mode != "feeder":
                 if trigger == "start-test-btn":
+                    print("[LAB TEST] Start button pressed")
+                    print("[LAB TEST] Active threads:", [t.name for t in threading.enumerate()])
                     try:
                         if active_machine_id is not None:
                             _reset_lab_session(active_machine_id)
@@ -5678,6 +5686,8 @@ def _register_callbacks_impl(app):
                 elif trigger == "stop-test-btn":
                     # Do not end the test immediately; allow a 30s grace period
                     # so logging can continue before finalizing.
+                    print("[LAB TEST] Stop button pressed - entering grace period")
+                    print("[LAB TEST] Active threads:", [t.name for t in threading.enumerate()])
                     return True
 
         feeders_running = False
@@ -5694,6 +5704,7 @@ def _register_callbacks_impl(app):
 
         if start_mode == "feeder" and feeders_running and not running:
 
+            print("[LAB TEST] Auto-starting test because feeders are running")
 
             try:
                 if active_machine_id is not None:
@@ -5710,6 +5721,7 @@ def _register_callbacks_impl(app):
 
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - abs(stop_time) >= 30):
+            print("[LAB TEST] Grace period complete - stopping test")
             current_lab_filename = None
             try:
                 refresh_lab_cache(active_machine_id)
@@ -5772,8 +5784,10 @@ def _register_callbacks_impl(app):
         if ctx.triggered:
             trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if trigger == "stop-test-btn":
+                print("[LAB TEST] Grace period timer started")
                 return -time.time()
             if trigger == "start-test-btn":
+                print("[LAB TEST] Grace period cleared due to start")
                 return None
 
         if not running:
@@ -5799,6 +5813,7 @@ def _register_callbacks_impl(app):
                 return None
         else:
             if start_mode == "feeder" and stop_time is None:
+                print("[LAB TEST] Feeders stopped - starting grace period")
                 return time.time()
 
         return dash.no_update
@@ -5979,8 +5994,10 @@ def _register_callbacks_impl(app):
             if new_mode != current_app_mode:
                 current_app_mode = new_mode
                 if new_mode == "lab":
+                    print("[LAB TEST] Lab mode activated - pausing background threads")
                     pause_background_processes()
                 else:
+                    print("[LAB TEST] Exiting lab mode - resuming background threads")
                     resume_background_processes()
         return dash.no_update
 


### PR DESCRIPTION
## Summary
- add extensive console prints for lab test actions
- log active threads when lab mode starts/stops
- print thread info during pause/resume operations

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f87c350c8327ad6d81c94bc3752a