### PR TITLE
Improve lab test stop timer diagnostics

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5719,6 +5719,7 @@ def _register_callbacks_impl(app):
                 logger.warning(f"Failed to prepare auto lab log: {exc}")
             return True
 
+        print(f"[LAB TEST DEBUG] running={running}, stop_time={stop_time}", flush=True)
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - abs(stop_time) >= 30):
             print("[LAB TEST] Grace period complete - stopping test", flush=True)


### PR DESCRIPTION
## Summary
- add debugging output for lab test stop condition

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68811577c5a8832793cbc4a4e8ce0cfd