### PR TITLE
Improve lab test stop timer diagnostics

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5667,12 +5667,16 @@ def _register_callbacks_impl(app):
         """Update lab running state based on start/stop actions or feeder status."""
         global current_lab_filename
         ctx = callback_context
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0] if ctx.triggered else "interval"
+        print(
+            f"[LAB TEST DEBUG] update_lab_running trigger={trigger} running={running}, stop_time={stop_time}",
+            flush=True,
+        )
 
         if mode != "lab":
             return False
 
         if ctx.triggered:
-            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if start_mode != "feeder":
                 if trigger == "start-test-btn":
                     print("[LAB TEST] Start button pressed", flush=True)
@@ -5719,6 +5723,7 @@ def _register_callbacks_impl(app):
                 logger.warning(f"Failed to prepare auto lab log: {exc}")
             return True
 
+        print(f"[LAB TEST DEBUG] running={running}, stop_time={stop_time}", flush=True)
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - abs(stop_time) >= 30):
             print("[LAB TEST] Grace period complete - stopping test", flush=True)
@@ -5781,13 +5786,21 @@ def _register_callbacks_impl(app):
     )
     def update_lab_test_stop_time(start_click, stop_click, n_intervals, running, stop_time, mode, active_machine_data, start_mode):
         ctx = callback_context
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0] if ctx.triggered else "interval"
+        print(
+            f"[LAB TEST DEBUG] update_lab_test_stop_time trigger={trigger} running={running}, stop_time={stop_time}",
+            flush=True,
+        )
+
         if ctx.triggered:
-            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if trigger == "stop-test-btn":
+                new_time = -time.time()
                 print("[LAB TEST] Grace period timer started", flush=True)
-                return -time.time()
+                print(f"[LAB TEST DEBUG] returning stop_time={new_time}", flush=True)
+                return new_time
             if trigger == "start-test-btn":
                 print("[LAB TEST] Grace period cleared due to start", flush=True)
+                print("[LAB TEST DEBUG] clearing stop_time", flush=True)
                 return None
 
         if not running:
@@ -5810,11 +5823,14 @@ def _register_callbacks_impl(app):
 
         if any_running:
             if stop_time is not None and stop_time >= 0:
+                print("[LAB TEST DEBUG] feeders running - clearing stop time", flush=True)
                 return None
         else:
             if start_mode == "feeder" and stop_time is None:
+                new_time = time.time()
                 print("[LAB TEST] Feeders stopped - starting grace period", flush=True)
-                return time.time()
+                print(f"[LAB TEST DEBUG] returning stop_time={new_time}", flush=True)
+                return new_time
 
         return dash.no_update
 


### PR DESCRIPTION
## Summary
- add debugging output for lab test stop condition
- log the stop time value being returned when starting or clearing the grace period

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68811577c5a8832793cbc4a4e8ce0cfd