### PR TITLE
Improve lab test stop timer diagnostics

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1025,6 +1025,11 @@ def _register_callbacks_impl(app):
         [State("lab-test-stop-time", "data")]
     )
     def disable_report_button(n_intervals, running, stop_time):
+        print(
+            f"[LAB TEST DEBUG] disable_report_button running={running}, "
+            f"stop_time={stop_time}",
+            flush=True,
+        )
         if running:
             return True
         if stop_time is None:
@@ -5638,11 +5643,17 @@ def _register_callbacks_impl(app):
     )
     def toggle_lab_test_buttons(running, mode, n_intervals, stop_time):
         """Enable/disable lab start/stop buttons based on test state."""
+        print(
+            f"[LAB TEST DEBUG] toggle_lab_test_buttons running={running}, "
+            f"stop_time={stop_time}",
+            flush=True,
+        )
         if mode != "lab":
             return True, "secondary", True, "secondary"
 
         # Disable both buttons during the 30s grace period after stopping
         if running and stop_time and (time.time() - abs(stop_time) < 30):
+            print("[LAB TEST DEBUG] grace period active - buttons disabled", flush=True)
             return True, "secondary", True, "secondary"
 
         if running:
@@ -5667,12 +5678,16 @@ def _register_callbacks_impl(app):
         """Update lab running state based on start/stop actions or feeder status."""
         global current_lab_filename
         ctx = callback_context
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0] if ctx.triggered else "interval"
+        print(
+            f"[LAB TEST DEBUG] update_lab_running trigger={trigger} running={running}, stop_time={stop_time}",
+            flush=True,
+        )
 
         if mode != "lab":
             return False
 
         if ctx.triggered:
-            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if start_mode != "feeder":
                 if trigger == "start-test-btn":
                     print("[LAB TEST] Start button pressed", flush=True)
@@ -5719,6 +5734,7 @@ def _register_callbacks_impl(app):
                 logger.warning(f"Failed to prepare auto lab log: {exc}")
             return True
 
+        print(f"[LAB TEST DEBUG] running={running}, stop_time={stop_time}", flush=True)
         # Check if we should end the test based on the stop time
         if running and stop_time and (time.time() - abs(stop_time) >= 30):
             print("[LAB TEST] Grace period complete - stopping test", flush=True)
@@ -5781,13 +5797,21 @@ def _register_callbacks_impl(app):
     )
     def update_lab_test_stop_time(start_click, stop_click, n_intervals, running, stop_time, mode, active_machine_data, start_mode):
         ctx = callback_context
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0] if ctx.triggered else "interval"
+        print(
+            f"[LAB TEST DEBUG] update_lab_test_stop_time trigger={trigger} running={running}, stop_time={stop_time}",
+            flush=True,
+        )
+
         if ctx.triggered:
-            trigger = ctx.triggered[0]["prop_id"].split(".")[0]
             if trigger == "stop-test-btn":
+                new_time = -time.time()
                 print("[LAB TEST] Grace period timer started", flush=True)
-                return -time.time()
+                print(f"[LAB TEST DEBUG] storing stop_time={new_time}", flush=True)
+                return new_time
             if trigger == "start-test-btn":
                 print("[LAB TEST] Grace period cleared due to start", flush=True)
+                print("[LAB TEST DEBUG] clearing stop_time", flush=True)
                 return None
 
         if not running:
@@ -5810,11 +5834,14 @@ def _register_callbacks_impl(app):
 
         if any_running:
             if stop_time is not None and stop_time >= 0:
+                print("[LAB TEST DEBUG] feeders running - clearing stop time", flush=True)
                 return None
         else:
             if start_mode == "feeder" and stop_time is None:
+                new_time = time.time()
                 print("[LAB TEST] Feeders stopped - starting grace period", flush=True)
-                return time.time()
+                print(f"[LAB TEST DEBUG] storing stop_time={new_time}", flush=True)
+                return new_time
 
         return dash.no_update
 


### PR DESCRIPTION
## Summary
- add explicit 'storing stop_time' debug messages
- add more debug prints when toggling lab test buttons and disabling report generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68811577c5a8832793cbc4a4e8ce0cfd