### PR TITLE
Fix lab mode thread stall

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5960,6 +5960,10 @@ def _register_callbacks_impl(app):
                             _reset_lab_session(active_machine_id)
                     except Exception as exc:
                         logger.warning(f"Failed to reset lab session: {exc}")
+                # Ensure the background update thread resumes when a test starts
+                # so lab mode does not stall waiting for the monitor interval to
+                # restart it.
+                resume_update_thread()
                 new_running = True
                 new_stop_time = None
                 _debug(f"[LAB TEST DEBUG] START: new_running={new_running}, new_stop_time={new_stop_time}")


### PR DESCRIPTION
## Summary
- restart the OPC update thread whenever a lab test starts to prevent stalls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882da06bb6883279d64440b7545bab1