### PR TITLE
Fix lab update thread stall

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -5960,6 +5960,9 @@ def _register_callbacks_impl(app):
                             _reset_lab_session(active_machine_id)
                     except Exception as exc:
                         logger.warning(f"Failed to reset lab session: {exc}")
+                # Resume the background update thread immediately so lab mode
+                # continues updating without waiting for the monitor watchdog.
+                resume_update_thread()
                 new_running = True
                 new_stop_time = None
                 _debug(f"[LAB TEST DEBUG] START: new_running={new_running}, new_stop_time={new_stop_time}")


### PR DESCRIPTION
## Summary
- restart the background OPC update thread at the start of every lab test
- clarify comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882da06bb6883279d64440b7545bab1