### PR TITLE
Improve lab test state and add watchdog

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -139,14 +139,14 @@ def test_lab_buttons_callback(monkeypatch):
     # Not running yet
 
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
     res = func.__wrapped__(False, None, "lab")
 
     assert res == (False, "success", True, "secondary")
 
     # Running
     callbacks._lab_running_state = True
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     res = func.__wrapped__(True, None, "lab")
 
@@ -154,16 +154,16 @@ def test_lab_buttons_callback(monkeypatch):
 
     # Grace period after stopping
     callbacks._lab_running_state = True
-    callbacks._lab_stop_time_state = -90.0
+    callbacks._grace_start_time = 90.0
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
 
-    res = func.__wrapped__(True, -90.0, "lab")
+    res = func.__wrapped__(True, 90.0, "lab")
 
     assert res == (True, "secondary", True, "secondary")
 
     # Other mode
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     res = func.__wrapped__(False, None, "live")
 
@@ -214,18 +214,18 @@ def test_generate_report_disable_callback(monkeypatch):
 
     callbacks._lab_running_state = True
 
-    callbacks._lab_stop_time_state = 90
+    callbacks._grace_start_time = 90
 
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
     assert func.__wrapped__(0, True, 90) is True
 
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = 95
+    callbacks._grace_start_time = 95
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
     assert func.__wrapped__(0, False, 95) is True
 
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = 50
+    callbacks._grace_start_time = 50
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
     assert func.__wrapped__(0, False, 50) is False
 
@@ -236,7 +236,7 @@ def test_lab_auto_start(monkeypatch):
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
@@ -263,7 +263,7 @@ def test_lab_local_mode_no_auto_start(monkeypatch):
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
@@ -291,7 +291,7 @@ def test_lab_auto_stop_sets_time(monkeypatch):
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
@@ -317,7 +317,7 @@ def test_lab_restart_clears_stop_time(monkeypatch):
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     callbacks._lab_running_state = False
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
@@ -342,7 +342,7 @@ def test_manual_stop_sets_negative_time(monkeypatch):
     app = dash.Dash(__name__)
     callbacks.register_callbacks(app)
     callbacks._lab_running_state = True
-    callbacks._lab_stop_time_state = None
+    callbacks._grace_start_time = None
 
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
@@ -354,7 +354,7 @@ def test_manual_stop_sets_negative_time(monkeypatch):
     monkeypatch.setattr(callbacks.time, "time", lambda: 456.0)
 
     res = func.__wrapped__(None, 1, "lab", 0, True, None, "AutoTest", {"mode": "lab"}, {"machine_id": 1}, "feeder")
-    assert res[1] == -456.0
+    assert res[1] == 456.0
 
 
 def test_grace_period_failsafe(monkeypatch):
@@ -372,12 +372,12 @@ def test_grace_period_failsafe(monkeypatch):
 
     # Simulate globals indicating running with stale stop time 50s ago
     callbacks._lab_running_state = True
-    callbacks._lab_stop_time_state = -50.0
+    callbacks._grace_start_time = 50.0
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
 
     # Toggle buttons should treat test as stopped
 
-    assert toggle_func.__wrapped__(0, True, -50.0, "lab") == (
+    assert toggle_func.__wrapped__(0, True, 50.0, "lab") == (
 
         False,
         "success",
@@ -386,7 +386,7 @@ def test_grace_period_failsafe(monkeypatch):
     )
 
     # Report button should be enabled
-    assert report_func.__wrapped__(0, False, -50.0) is False
+    assert report_func.__wrapped__(0, False, 50.0) is False
 
 def test_update_lab_state_failsafe(monkeypatch):
     """update_lab_state should clear stale grace period even without interval."""
@@ -397,7 +397,7 @@ def test_update_lab_state_failsafe(monkeypatch):
     func = app.callback_map["..lab-test-running.data...lab-test-stop-time.data.."]["callback"]
 
     callbacks._lab_running_state = True
-    callbacks._lab_stop_time_state = -50.0
+    callbacks._grace_start_time = 50.0
 
     class DummyCtx:
         def __init__(self, prop_id):
@@ -407,7 +407,7 @@ def test_update_lab_state_failsafe(monkeypatch):
     monkeypatch.setattr(callbacks.time, "time", lambda: 100.0)
 
     # Failsafe should mark test stopped before handling new start click
-    res = func.__wrapped__(1, 0, "lab", 0, True, -50.0, "AutoTest", {"mode": "lab"}, {"machine_id": 1}, "feeder")
+    res = func.__wrapped__(1, 0, "lab", 0, True, 50.0, "AutoTest", {"mode": "lab"}, {"machine_id": 1}, "feeder")
 
     assert res == (True, None)
 


### PR DESCRIPTION
## Summary
- simplify lab state globals and remove negative timestamps
- add watchdog timer for stalled UI updates
- track grace period with boolean timestamp system
- update tests for new logic

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e6ba0e208327b8bbccf0e6e2ad01