### PR TITLE
Fix reject percentage in lab mode

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -3015,9 +3015,14 @@ def _register_callbacks_impl(app):
             rejects = production_data.get("rejects", 2500)
         
         # Calculate percentages
-        total = accepts + rejects
-        accepts_percent = (accepts / total * 100) if total > 0 else 0
-        rejects_percent = (rejects / total * 100) if total > 0 else 0
+        if mode == "lab" and _lab_running_state:
+            total = capacity_count
+            accepts_percent = (accepts_count / total * 100) if total > 0 else 0
+            rejects_percent = (reject_count / total * 100) if total > 0 else 0
+        else:
+            total = accepts + rejects
+            accepts_percent = (accepts / total * 100) if total > 0 else 0
+            rejects_percent = (rejects / total * 100) if total > 0 else 0
         
         # Format values with commas for thousands separator and limited decimal places
         if total_capacity_formatted is None:

--- a/tests/test_update_section_1_1.py
+++ b/tests/test_update_section_1_1.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import dash
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import callbacks
+import autoconnect
+
+
+def test_update_section_1_1_lab_running_counts(monkeypatch):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    key = next(k for k in app.callback_map if 'section-1-1' in k)
+    func = app.callback_map[key]["callback"]
+
+    callbacks._lab_running_state = True
+    callbacks.active_machine_id = 1
+    callbacks._lab_production_cache[1] = {
+        "mtime": 0,
+        "size": 0,
+        "production_data": {"capacity": 100, "accepts": 80, "rejects": 20},
+        "capacity_count": 10,
+        "accepts_count": 8,
+        "reject_count": 2,
+    }
+
+    section, _ = func.__wrapped__(
+        0,
+        "main",
+        {},
+        {},
+        "en",
+        {"connected": True},
+        {"mode": "lab"},
+        {"capacity": 0, "accepts": 0, "rejects": 0},
+        {"unit": "kg"},
+    )
+
+    accept_row = section.children[2]
+    reject_row = section.children[3]
+    assert accept_row.children[-1].children == "(80.00%)"
+    assert reject_row.children[-1].children == "(20.00%)"


### PR DESCRIPTION
## Summary
- compute percentages using counts when a lab test is running
- add regression test for section 1-1 percentages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f23e3a6483279c9998437400fb28