### PR TITLE
Preserve display settings description element

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -5195,7 +5195,8 @@ def create_display_settings_form(lang=_initial_lang):
     # Add header
     header = html.Div(
         tr("display_settings_header", lang),
-        className="mb-3 fw-bold"
+        className="mb-3 fw-bold",
+        id="display-modal-description"
     )
     
     # Return the form with header

--- a/tests/test_update_section_1_2.py
+++ b/tests/test_update_section_1_2.py
@@ -26,6 +26,7 @@ def test_update_section_1_2_filters_inactive(monkeypatch):
         {},
         {},
         "counts",
+        [10, 20] + [0] * 10,
         {"connected": True},
         {"mode": "lab"}
     )


### PR DESCRIPTION
## Summary
- Keep the `display-modal-description` element when rebuilding the display settings form so callbacks always have a valid target.
- Adjust test for section 1-2 updates to match updated callback signature.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d5ba81848327a73b6bd5d7e1a13c