### PR TITLE
Ensure machine card heights are uniform

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -4273,12 +4273,16 @@ def create_enhanced_machine_card_with_selection(machine, ip_options, floors_data
         # Disconnected - light grey background
         card_class = "mb-2 machine-card-disconnected"
 
+    # Ensure all machine cards grow to the height of the tallest card
+    card_class += " h-100"
+
     # Base style for positioning
     card_style = {
         "position": "relative",
         "cursor": "pointer",
         "transition": "all 0.2s ease-in-out",
-        "flexWrap": "wrap"
+        "flexWrap": "wrap",
+        "height": "100%"
     }
     
     # Get operational data ONLY if actually connected


### PR DESCRIPTION
## Summary
- Force machine cards in the legacy dashboard to grow to the tallest card by appending `h-100` and a 100% height style.
- Revert changes to the original dashboard so it remains unmodified.

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e1fc3a6c8327838752e23ec50ab0