### PR TITLE
Align card borders with header color

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2013,7 +2013,7 @@ app.index_string = """<!DOCTYPE html>
                 --bs-body-bg: #f0f0f0;
                 --bs-body-color: #212529;
                 --bs-card-bg: #ffffff;
-                --bs-card-border-color: rgba(0,0,0,0.125);
+                --bs-card-border-color: #0d6efd;
                 --chart-bg: rgba(255,255,255,0.9);
             }
             
@@ -2048,7 +2048,7 @@ app.index_string = """<!DOCTYPE html>
                 margin-bottom: 0.5rem;
                 box-shadow: 0 2px 5px rgba(0,0,0,0.1);
                 background-color: var(--bs-card-bg) !important;
-                border-color: var(--bs-card-border-color) !important;
+                border: 2px solid var(--bs-card-border-color) !important;
                 color: var(--bs-body-color) !important;
                 transition: background-color 0.3s, color 0.3s, border-color 0.3s;
             }

--- a/callbacks.py
+++ b/callbacks.py
@@ -829,14 +829,14 @@ def _register_callbacks_impl(app):
                     backgroundColor: "#f0f0f0",
                     cardBackgroundColor: "#ffffff",
                     textColor: "#212529",
-                    borderColor: "rgba(0,0,0,0.125)",
+                    borderColor: "#0d6efd",
                     chartBackgroundColor: "rgba(255,255,255,0.9)"
                 },
                 dark: {
                     backgroundColor: "#202124",
                     cardBackgroundColor: "#2d2d30",
                     textColor: "#e8eaed",
-                    borderColor: "rgba(255,255,255,0.125)",
+                    borderColor: "#0d6efd",
                     chartBackgroundColor: "rgba(45,45,48,0.9)"
                 }
             };


### PR DESCRIPTION
## Summary
- set card border color variable to the primary header color in the legacy dashboard
- increase card border width to 2px and sync theme settings for light and dark modes
- restore the original dashboard script to keep its default border styling

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e296389083278afc71c22b96ee7c