### PR TITLE
Align card borders with header color

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2013,7 +2013,7 @@ app.index_string = """<!DOCTYPE html>
                 --bs-body-bg: #f0f0f0;
                 --bs-body-color: #212529;
                 --bs-card-bg: #ffffff;
-                --bs-card-border-color: rgba(0,0,0,0.125);
+                --bs-card-border-color: var(--bs-primary);
                 --chart-bg: rgba(255,255,255,0.9);
             }
             
@@ -2048,7 +2048,7 @@ app.index_string = """<!DOCTYPE html>
                 margin-bottom: 0.5rem;
                 box-shadow: 0 2px 5px rgba(0,0,0,0.1);
                 background-color: var(--bs-card-bg) !important;
-                border-color: var(--bs-card-border-color) !important;
+                border: 2px solid var(--bs-card-border-color) !important;
                 color: var(--bs-body-color) !important;
                 transition: background-color 0.3s, color 0.3s, border-color 0.3s;
             }

--- a/callbacks.py
+++ b/callbacks.py
@@ -829,14 +829,12 @@ def _register_callbacks_impl(app):
                     backgroundColor: "#f0f0f0",
                     cardBackgroundColor: "#ffffff",
                     textColor: "#212529",
-                    borderColor: "rgba(0,0,0,0.125)",
                     chartBackgroundColor: "rgba(255,255,255,0.9)"
                 },
                 dark: {
                     backgroundColor: "#202124",
                     cardBackgroundColor: "#2d2d30",
                     textColor: "#e8eaed",
-                    borderColor: "rgba(255,255,255,0.125)",
                     chartBackgroundColor: "rgba(45,45,48,0.9)"
                 }
             };
@@ -847,7 +845,6 @@ def _register_callbacks_impl(app):
                 root.style.setProperty("--bs-body-bg", themeColors.dark.backgroundColor);
                 root.style.setProperty("--bs-body-color", themeColors.dark.textColor);
                 root.style.setProperty("--bs-card-bg", themeColors.dark.cardBackgroundColor);
-                root.style.setProperty("--bs-card-border-color", themeColors.dark.borderColor);
                 root.style.setProperty("--chart-bg", themeColors.dark.chartBackgroundColor);
 
                 // Add dark-mode class to body for additional CSS targeting
@@ -861,7 +858,6 @@ def _register_callbacks_impl(app):
                 root.style.setProperty("--bs-body-bg", themeColors.light.backgroundColor);
                 root.style.setProperty("--bs-body-color", themeColors.light.textColor);
                 root.style.setProperty("--bs-card-bg", themeColors.light.cardBackgroundColor);
-                root.style.setProperty("--bs-card-border-color", themeColors.light.borderColor);
                 root.style.setProperty("--chart-bg", themeColors.light.chartBackgroundColor);
 
                 // Add light-mode class to body for additional CSS targeting
@@ -871,6 +867,10 @@ def _register_callbacks_impl(app):
                 // Store theme preference in localStorage
                 localStorage.setItem("satake-theme", "light");
             }
+
+            // Sync card borders with the Bootstrap primary color
+            const primaryColor = getComputedStyle(root).getPropertyValue("--bs-primary").trim();
+            root.style.setProperty("--bs-card-border-color", primaryColor);
 
             // Update all Plotly charts with new theme
             if (window.Plotly) {


### PR DESCRIPTION
## Summary
- derive card border color from Bootstrap's primary tone so borders match the top header hue
- update the theme switcher to pull the primary color for borders in both light and dark modes

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e296389083278afc71c22b96ee7c