### PR TITLE
fix: correct spacing below connection card in dark mode

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2606,7 +2606,8 @@ def connection_controls(lang=_initial_lang):
             ], width=0, style={"display": "none"}),
         ], className="gx-2 align-items-center"),
     ], className="py-1 px-2"),
-    className="mb-1 mt-0",
+    className="mb-2 mt-0",
+    style={"boxShadow": "none"},
     )
 settings_modal = dbc.Modal([
     dbc.ModalHeader(html.Span(tr("system_settings_title"), id="settings-modal-header")),


### PR DESCRIPTION
## Summary
- add bottom margin to connection controls card
- remove shadow bleed in dark theme by disabling card box shadow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f3544ea083278b4e4cfcfab4dba9