### PR TITLE
fix: correct connection card styling in dark mode

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2605,8 +2605,13 @@ def connection_controls(lang=_initial_lang):
                 ),
             ], width=0, style={"display": "none"}),
         ], className="gx-2 align-items-center"),
-    ], className="py-1 px-2"),
-    className="mb-1 mt-0",
+    ], className="py-1 px-2", style={"backgroundColor": "var(--bs-card-bg)"}),
+    className="mb-2 mt-0",
+    style={
+        "boxShadow": "none",
+        "backgroundColor": "var(--bs-card-bg)",
+        "borderColor": "var(--bs-border-color)",
+    },
     )
 settings_modal = dbc.Modal([
     dbc.ModalHeader(html.Span(tr("system_settings_title"), id="settings-modal-header")),
@@ -3258,7 +3263,7 @@ app.layout = html.Div([
         children=render_new_dashboard()
     ),
 
-], className="main-app-container")
+], className="main-app-container", style={"backgroundColor": "var(--bs-card-bg)"})
 from callbacks import register_callbacks
 
 def load_historical_data(timeframe="24h", machine_id=None):


### PR DESCRIPTION
## Summary
- ensure connection controls card and surrounding container use theme card background to avoid black gap in dark mode
- keep card shadow disabled to prevent bleed

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f3544ea083278b4e4cfcfab4dba9