### PR TITLE
Use muted gray card borders

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -2013,7 +2013,7 @@ app.index_string = """<!DOCTYPE html>
                 --bs-body-bg: #f0f0f0;
                 --bs-body-color: #212529;
                 --bs-card-bg: #ffffff;
-                
+                --bs-card-border-color: #6c757d;
                 --chart-bg: rgba(255,255,255,0.9);
             }
             
@@ -2049,7 +2049,7 @@ app.index_string = """<!DOCTYPE html>
                 box-shadow: 0 2px 5px rgba(0,0,0,0.1);
                 background-color: var(--bs-card-bg) !important;
 
-                border: 2px solid var(--bs-primary) !important;
+                border: 2px solid var(--bs-card-border-color) !important;
 
                 color: var(--bs-body-color) !important;
                 transition: background-color 0.3s, color 0.3s, border-color 0.3s;

--- a/callbacks.py
+++ b/callbacks.py
@@ -870,9 +870,8 @@ def _register_callbacks_impl(app):
                 localStorage.setItem("satake-theme", "light");
             }
 
-            // Sync card borders with the Bootstrap primary color
-            const primaryColor = getComputedStyle(root).getPropertyValue("--bs-primary").trim();
-            root.style.setProperty("--bs-card-border-color", primaryColor);
+            // Ensure card borders use a muted gray
+            root.style.setProperty("--bs-card-border-color", "#6c757d");
 
             // Update all Plotly charts with new theme
             if (window.Plotly) {


### PR DESCRIPTION
## Summary
- Define `--bs-card-border-color` CSS variable and set it to `#6c757d`
- Apply the new border color to card components and sync in callbacks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1185bc508327b933fb4ae0d0c0ff