### PR TITLE
Format Ejector Delay with one decimal in lab report

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -1270,10 +1270,12 @@ def draw_machine_settings_section(c, x0, y0, total_w, section_h, settings, *, la
             y = y0 + section_h - (r + rs) * row_h
             w = cs * col_w
             h = rs * row_h
-            if r == 2 and j == 1:  # Ejector Dwell cell (PrimaryDwell)
+            if (r, j) in [(2, 1), (5, 1)]:  # Ejector Dwell or Delay cell
                 try:
-                    # Format the Ejector Dwell to 1 decimal place
-                    text = f"{float(cell):.1f}" if cell not in {"N/A", "", "None", None} else str(cell)
+                    # Format the Ejector Dwell/Delay to 1 decimal place
+                    text = (
+                        f"{float(cell):.1f}" if cell not in {"N/A", "", "None", None} else str(cell)
+                    )
                 except (ValueError, TypeError):
                     text = str(cell)
             else:

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -37,6 +37,44 @@ def test_load_machine_settings(tmp_path):
     assert data == {"value": 1}
 
 
+def test_machine_settings_delay_formatted_one_decimal():
+    class DummyCanvas:
+        def __init__(self):
+            self.texts = []
+
+        def saveState(self):
+            pass
+
+        def restoreState(self):
+            pass
+
+        def setStrokeColor(self, *a, **k):
+            pass
+
+        def line(self, *a, **k):
+            pass
+
+        def rect(self, *a, **k):
+            pass
+
+        def setFillColor(self, *a, **k):
+            pass
+
+        def setFont(self, *a, **k):
+            pass
+
+        def drawString(self, x, y, text):
+            self.texts.append(text)
+
+    c = DummyCanvas()
+    settings = {"Settings": {"Ejectors": {"PrimaryDelay": 12.345}}}
+    generate_report.draw_machine_settings_section(c, 0, 0, 100, 60, settings)
+
+    assert "Ejector Delay:" in c.texts
+    assert "12.3" in c.texts
+    assert "12.345" not in c.texts
+
+
 def test_bool_from_setting_case_insensitive():
     assert generate_report._bool_from_setting("TRUE") is True
     assert generate_report._bool_from_setting("FALSE") is False


### PR DESCRIPTION
## Summary
- format Ejector Delay values to one decimal place in lab reports
- test that machine settings section outputs formatted delay

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a20fc4c908327b48d8e945da2c747