### PR TITLE
Handle missing add-machine button

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -3090,6 +3090,8 @@ def render_main_dashboard(lang=_initial_lang):
         # Hidden placeholder so callbacks referencing this ID don't warn when
         # the main dashboard is active
         html.Button(id="add-floor-btn", style={"display": "none"}),
+        # Hidden placeholder for callbacks that depend on add-machine-btn
+        html.Button(id="add-machine-btn", style={"display": "none"}),
     ],
     style={
         'backgroundColor': '#f0f0f0',

--- a/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
+++ b/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
@@ -5808,7 +5808,7 @@ def show_floor_save_status(add_clicks, save_clicks, delete_clicks):
 
 @app.callback(
     Output("save-status", "children", allow_duplicate=True),
-    [Input("add-machine-btn", "n_clicks"),
+    [Input("add-machine-btn", "n_clicks", allow_optional=True),
      Input({"type": "machine-ip-dropdown", "index": ALL}, "value")],
     prevent_initial_call=True
 )
@@ -5862,7 +5862,7 @@ def manual_save_layout(n_clicks, floors_data, machines_data):
 # Enhanced callback for adding machines with auto-save
 @app.callback(
     Output("machines-data", "data", allow_duplicate=True),
-    [Input("add-machine-btn", "n_clicks")],
+    [Input("add-machine-btn", "n_clicks", allow_optional=True)],
     [State("machines-data", "data"),
      State("floors-data", "data")],
     prevent_initial_call=True

--- a/callbacks.py
+++ b/callbacks.py
@@ -2641,7 +2641,7 @@ def _register_callbacks_impl(app):
 
     @app.callback(
         Output("save-status", "children", allow_duplicate=True),
-        [Input("add-machine-btn", "n_clicks"),
+        [Input("add-machine-btn", "n_clicks", allow_optional=True),
          Input({"type": "machine-ip-dropdown", "index": ALL}, "value")],
         prevent_initial_call=True
     )
@@ -2674,7 +2674,7 @@ def _register_callbacks_impl(app):
 
     @app.callback(
         Output("machines-data", "data", allow_duplicate=True),
-        [Input("add-machine-btn", "n_clicks")],
+        [Input("add-machine-btn", "n_clicks", allow_optional=True)],
         [State("machines-data", "data"),
          State("floors-data", "data")],
         prevent_initial_call=True


### PR DESCRIPTION
## Summary
- avoid dash callback errors when switching dashboards by adding a hidden `add-machine-btn`
- make add-machine callbacks tolerant to missing button components

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a24d9cf908327b53f015bf2b82624