### PR TITLE
Handle missing add-machine button

### DIFF
--- a/EnpresorOPCDataViewBeforeRestructureLegacy.py
+++ b/EnpresorOPCDataViewBeforeRestructureLegacy.py
@@ -3090,6 +3090,8 @@ def render_main_dashboard(lang=_initial_lang):
         # Hidden placeholder so callbacks referencing this ID don't warn when
         # the main dashboard is active
         html.Button(id="add-floor-btn", style={"display": "none"}),
+        # Hidden placeholder for callbacks that depend on add-machine-btn
+        html.Button(id="add-machine-btn", style={"display": "none"}),
     ],
     style={
         'backgroundColor': '#f0f0f0',

--- a/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
+++ b/EnpresorOPCDataViewBeforeRestructureORIGINAL.py
@@ -2503,7 +2503,9 @@ def _render_new_dashboard():
             html.Div(id="section-6-2", children=[], style={"display": "none"}),
             html.Div(id="section-7-1", children=[], style={"display": "none"}),
             html.Div(id="section-7-2", children=[], style={"display": "none"}),
-        ])
+        ]),
+        # Hidden placeholder for callbacks that reference add-machine-btn
+        html.Button(id="add-machine-btn", style={"display": "none"})
     ])
 
 


### PR DESCRIPTION
## Summary
- avoid dash callback errors when switching dashboards by adding a hidden `add-machine-btn`
- make add-machine callbacks tolerant to missing button components

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`
- `timeout 5s python EnpresorOPCDataViewBeforeRestructureLegacy.py`

------
https://chatgpt.com/codex/tasks/task_e_689a24d9cf908327b53f015bf2b82624