### PR TITLE
Remove unsupported allow_optional in Dash callbacks

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -2641,7 +2641,7 @@ def _register_callbacks_impl(app):
 
     @app.callback(
         Output("save-status", "children", allow_duplicate=True),
-        [Input("add-machine-btn", "n_clicks", allow_optional=True),
+        [Input("add-machine-btn", "n_clicks"),
          Input({"type": "machine-ip-dropdown", "index": ALL}, "value")],
         prevent_initial_call=True
     )
@@ -2674,7 +2674,7 @@ def _register_callbacks_impl(app):
 
     @app.callback(
         Output("machines-data", "data", allow_duplicate=True),
-        [Input("add-machine-btn", "n_clicks", allow_optional=True)],
+        [Input("add-machine-btn", "n_clicks")],
         [State("machines-data", "data"),
          State("floors-data", "data")],
         prevent_initial_call=True


### PR DESCRIPTION
## Summary
- drop `allow_optional` argument from Dash `Input` definitions to avoid `TypeError`

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3ee056348327aa5e4ed8a99b5429