### PR TITLE
Compute lab weight multiplier from machine tags

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -32,8 +32,8 @@ COUNT_VALUE_FONT_SIZE = 18
 SENSITIVITY_VALUE_FONT_SIZE = 10
 LAB_OBJECT_SCALE_FACTOR = 1.042
 
-# Weight conversion for lab metrics: 1 lbs per 1800 pieces
-
+# Weight conversion for lab metrics calculated from test weight tags.
+# Fallback multiplier: 1 lb per 1800 pieces.
 LAB_WEIGHT_MULTIPLIER = 1 / 1800
 
 from i18n import tr
@@ -91,6 +91,46 @@ def _minutes_to_hm(minutes: float) -> str:
         m = 0
     hours, mins = divmod(m, 60)
     return f"{hours}:{mins:02d}"
+
+
+def _convert_to_lbs(value: float, unit: str) -> float:
+    """Convert ``value`` from ``unit`` to pounds."""
+    unit = str(unit).lower()
+    if unit in {"lb", "lbs", "pound", "pounds"}:
+        return value
+    if unit in {"oz", "ounce", "ounces"}:
+        return value / 16.0
+    if unit in {"g", "gram", "grams"}:
+        return value / 453.59237
+    if unit in {"kg", "kilogram", "kilograms"}:
+        return value * 2.20462262185
+    return value
+
+
+def lab_weight_multiplier_from_settings(settings: dict) -> float:
+    """Calculate lbs-per-object multiplier from machine settings.
+
+    Uses the ``Settings.ColorSort.TestWeightCount``,
+    ``Settings.ColorSort.TestWeightValue`` and ``Settings.ColorSort.TestWeightUnit``
+    tags if available. Falls back to :data:`LAB_WEIGHT_MULTIPLIER` when values are
+    missing or invalid.
+    """
+
+    count = _lookup_setting(settings, "Settings.ColorSort.TestWeightCount", 0)
+    value = _lookup_setting(settings, "Settings.ColorSort.TestWeightValue", 0)
+    unit = _lookup_setting(settings, "Settings.ColorSort.TestWeightUnit", "lb")
+
+    try:
+        count = float(count)
+        value = float(value)
+    except (TypeError, ValueError):
+        return LAB_WEIGHT_MULTIPLIER
+
+    if count <= 0:
+        return LAB_WEIGHT_MULTIPLIER
+
+    value_lbs = _convert_to_lbs(value, unit)
+    return value_lbs / count
 
 
 def calculate_total_capacity_from_csv_rates(
@@ -638,9 +678,10 @@ def draw_global_summary(
                 total_objects += machine_objects
                 total_removed += machine_removed
 
+                lab_mult = lab_weight_multiplier_from_settings(settings_data)
                 clean_objs = machine_objects - machine_removed
-                total_accepts += clean_objs * LAB_WEIGHT_MULTIPLIER
-                total_rejects += machine_removed * LAB_WEIGHT_MULTIPLIER
+                total_accepts += clean_objs * lab_mult
+                total_rejects += machine_removed * lab_mult
             else:
                 if ac:
                     stats = calculate_total_capacity_from_csv_rates(
@@ -2169,9 +2210,10 @@ def draw_machine_sections(
     machine_rejects = 0
 
     if is_lab_mode:
+        lab_mult = lab_weight_multiplier_from_settings(settings_data)
         clean_objects = machine_objs - machine_rem
-        machine_accepts = clean_objects * LAB_WEIGHT_MULTIPLIER
-        machine_rejects = machine_rem * LAB_WEIGHT_MULTIPLIER
+        machine_accepts = clean_objects * lab_mult
+        machine_rejects = machine_rem * lab_mult
     else:
         if ac_col:
             a_stats = calculate_total_capacity_from_csv_rates(

--- a/report_tags.py
+++ b/report_tags.py
@@ -21,6 +21,9 @@ REPORT_SETTINGS_TAGS = {
     "Settings.Calibration.FrontBackgroundBlue",
     "Status.Info.PresetName",
     "Status.Info.PresetNumber",
+    "Settings.ColorSort.TestWeightValue",
+    "Settings.ColorSort.TestWeightCount",
+    "Settings.ColorSort.TestWeightUnit",
     # Sensitivity specific tags for PDF reports
     *{
         f"Settings.ColorSort.Primary{i}.FrontAndRearLogic" for i in range(1, 13)

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -220,6 +220,28 @@ def test_enhanced_calculate_stats_respects_isassigned(tmp_path):
     assert stats["removed"] == pytest.approx(generate_report.LAB_OBJECT_SCALE_FACTOR)
 
 
+@pytest.mark.parametrize(
+    "unit,value",
+    [
+        ("lb", 1),
+        ("oz", 16),
+        ("g", 453.59237),
+        ("kg", 0.45359237),
+    ],
+)
+def test_lab_weight_multiplier_from_settings(unit, value):
+    settings = {
+        "Settings": {
+            "ColorSort": {
+                "TestWeightCount": 1800,
+                "TestWeightValue": value,
+                "TestWeightUnit": unit,
+            }
+        }
+    }
+    mult = generate_report.lab_weight_multiplier_from_settings(settings)
+    assert mult == pytest.approx(1 / 1800)
+
 
 def test_enhanced_calculate_stats_respects_isassigned(tmp_path):
     machine_dir = tmp_path / "1"

--- a/tests/test_report_tags.py
+++ b/tests/test_report_tags.py
@@ -1,5 +1,6 @@
 import json
 import importlib
+import json
 from pathlib import Path
 
 import report_tags


### PR DESCRIPTION
## Summary
- derive lab weight multiplier from TestWeightCount, TestWeightValue and TestWeightUnit tags
- include test weight tags in report settings export
- add coverage for unit conversions in lab weight multiplier

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5ce268588327a1cc74deea13a8ff