### PR TITLE
Fix lab mode weight calculation for section 1_1

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -19,6 +19,7 @@ import csv
 import re
 import threading
 import random
+import json
 
 def _debug(message: str) -> None:
     """Helper to print debug messages and persist them to a file."""
@@ -2954,41 +2955,30 @@ def _register_callbacks_impl(app):
                     if path
                     else None
                 )
+                if path:
+                    counts, _, objects = load_lab_totals(mid, active_counters=active_flags)
+                else:
+                    counts, objects = [0] * 12, []
+
+                reject_count = sum(
+                    c for c, active in zip(counts, active_flags) if active
+                )
+                capacity_count = objects[-1] if objects else 0
+                accepts_count = max(0, capacity_count - reject_count)
+
                 if metrics:
                     tot_cap_lbs, acc_lbs, rej_lbs, _ = metrics
-
-
-
-
-                    
-                    # Refresh cached totals so last-value helpers return
-                    # up-to-date data while respecting active sensitivities
-                    load_lab_totals(mid, active_counters=active_flags)
-
-                    counter_rates = load_last_lab_counters(mid)
-                    capacity_rate = load_last_lab_objects(mid)
-
-                    reject_count = sum(
-                        rate for rate, active in zip(counter_rates, active_flags) if active
-                    ) * 60
-                    capacity_count = capacity_rate * 60
-                    accepts_count = max(0, capacity_count - reject_count)
                     total_capacity = convert_capacity_from_lbs(tot_cap_lbs, weight_pref)
                     accepts = convert_capacity_from_lbs(acc_lbs, weight_pref)
                     rejects = convert_capacity_from_lbs(rej_lbs, weight_pref)
-
-                    production_data = {
-                        "capacity": total_capacity,
-                        "accepts": accepts,
-                        "rejects": rejects,
-                    }
                 else:
-                    # No existing lab log yet. Use zeroed placeholders so the
-                    # dashboard doesn't display stale live values when switching
-                    # to lab mode.
                     total_capacity = accepts = rejects = 0
-                    capacity_count = accepts_count = reject_count = 0
-                    production_data = {"capacity": 0, "accepts": 0, "rejects": 0}
+
+                production_data = {
+                    "capacity": total_capacity,
+                    "accepts": accepts,
+                    "rejects": rejects,
+                }
 
                 _lab_production_cache[mid] = {
                     "mtime": mtime,

--- a/tests/test_update_section_1_1.py
+++ b/tests/test_update_section_1_1.py
@@ -123,3 +123,44 @@ def test_update_section_1_1_demo_matches_machine(monkeypatch):
     assert "pcs" not in reject_display
     assert "6.00" in reject_display
     assert prod == {"capacity": 100.0, "accepts": 94.0, "rejects": 6.0}
+
+
+def test_update_section_1_1_lab_weight_from_metrics(monkeypatch, tmp_path):
+    monkeypatch.setattr(autoconnect, "initialize_autoconnect", lambda: None)
+    app = dash.Dash(__name__)
+    callbacks.register_callbacks(app)
+    key = next(k for k in app.callback_map if 'section-1-1' in k)
+    func = app.callback_map[key]["callback"]
+
+    callbacks.hourly_data_saving.EXPORT_DIR = str(tmp_path)
+    machine_dir = tmp_path / "1"
+    machine_dir.mkdir()
+
+    csv_path = machine_dir / "Lab_Test_sample.csv"
+    csv_path.write_text(
+        "timestamp,accepts,rejects,objects_60M,counter_1\n"
+        "2025-01-01T00:00:00,54,6,1800,180\n"
+        "2025-01-01T00:01:00,54,6,1800,180\n"
+    )
+
+    callbacks._lab_production_cache.clear()
+    callbacks._lab_totals_cache.clear()
+    callbacks.active_machine_id = 1
+
+    section, _ = func.__wrapped__(
+        0,
+        "main",
+        {},
+        {},
+        "en",
+        {"connected": True},
+        {"mode": "lab"},
+        {"capacity": 0, "accepts": 0, "rejects": 0},
+        {"unit": "lb"},
+        {"machines": []},
+    )
+
+    accept_row = section.children[2]
+    reject_row = section.children[3]
+    assert "0.90 lb" in accept_row.children[2].children
+    assert "0.10 lb" in reject_row.children[2].children


### PR DESCRIPTION
## Summary
- derive lab-mode weights for section 1-1 from lab metrics instead of scaled object counts
- add regression test verifying accepts and rejects weights from lab metrics

## Testing
- `pip install -r requirements.txt -r test-requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a639789f4832785c1c936271f7f29