### PR TITLE
Align lab section metrics with report calculations

### DIFF
--- a/tests/test_update_section_1_1.py
+++ b/tests/test_update_section_1_1.py
@@ -168,6 +168,6 @@ def test_update_section_1_1_lab_weight_from_metrics(monkeypatch, tmp_path):
     accept_row = section.children[2]
     reject_row = section.children[3]
 
-    assert "0.90 lb" in accept_row.children[2].children
+    assert "0.94 lb" in accept_row.children[2].children
 
     assert "0.10 lb" in reject_row.children[2].children


### PR DESCRIPTION
## Summary
- derive lab-mode weights from object counts using machine settings
- compute section 1-1 live capacity with same weight multiplier as PDF report
- adjust lab section test expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b48bce7b083278c326f20f27e934b