### PR TITLE
Align lab section metrics with report calculations

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -178,6 +178,18 @@ def _get_latest_lab_file(machine_dir):
         return None
 
 
+def _load_lab_weight_multiplier(machine_id):
+    """Return lbs-per-object multiplier from saved machine settings."""
+    machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
+    settings_path = os.path.join(machine_dir, "settings.json")
+    if os.path.exists(settings_path):
+        try:
+            with open(settings_path, "r", encoding="utf-8") as fh:
+                settings_data = json.load(fh)
+            return generate_report.lab_weight_multiplier_from_settings(settings_data)
+        except Exception:
+            pass
+    return generate_report.LAB_WEIGHT_MULTIPLIER
 
 
 
@@ -285,9 +297,9 @@ def load_lab_totals(machine_id, filename=None, active_counters=None):
                         counter_totals[idx_c] += prev_val * delta_minutes * scale
 
 
-            opm = row.get("objects_60M")
+            opm = row.get("objects_per_min")
             if opm is None or opm == "":
-                opm = row.get("objects_per_min")
+                opm = row.get("objects_60M")
             try:
                 rate_val = float(opm) if opm else None
             except ValueError:
@@ -426,7 +438,10 @@ def load_last_lab_metrics(machine_id):
 
 
 def load_last_lab_objects(machine_id):
-    """Return the most recent ``objects_60M`` value from a lab log."""
+    """Return the most recent ``objects_per_min`` value from a lab log.
+
+    Falls back to ``objects_60M`` when per-minute data is unavailable.
+    """
     machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
     path = _get_latest_lab_file(machine_dir)
     if not path or not os.path.exists(path):
@@ -456,7 +471,7 @@ def load_last_lab_objects(machine_id):
     if not last_row:
         return 0
 
-    val = last_row.get("objects_60M") or last_row.get("objects_per_min")
+    val = last_row.get("objects_per_min") or last_row.get("objects_60M")
     try:
         return float(val) if val else 0
     except ValueError:
@@ -582,54 +597,27 @@ def _reset_lab_session_safe(machine_id):
 
 
 def load_lab_totals_metrics(machine_id, active_counters=None):
-    """Return total capacity, accepts, rejects and elapsed seconds from the latest lab log.
-
-    ``active_counters`` is accepted for API symmetry with :func:`load_lab_totals`
-    but is currently unused.
-    """
-    machine_dir = os.path.join(hourly_data_saving.EXPORT_DIR, str(machine_id))
-    path = _get_latest_lab_file(machine_dir)
-    if not path:
-        return None
-
-    accepts = []
-    rejects = []
-    timestamps = []
-
-    with open(path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            a = row.get("accepts")
-            r = row.get("rejects")
-            ts = row.get("timestamp")
-            try:
-                accepts.append(float(a)) if a else accepts.append(0.0)
-            except ValueError:
-                accepts.append(0.0)
-            try:
-                rejects.append(float(r)) if r else rejects.append(0.0)
-            except ValueError:
-                rejects.append(0.0)
-            if ts:
-                timestamps.append(ts)
-
-    a_stats = generate_report.calculate_total_capacity_from_csv_rates(
-        accepts, timestamps=timestamps, is_lab_mode=True
+    """Return total capacity, accepts, rejects and elapsed seconds from the latest lab log."""
+    counts, timestamps, object_totals = load_lab_totals(
+        machine_id, active_counters=active_counters
     )
-    r_stats = generate_report.calculate_total_capacity_from_csv_rates(
-        rejects, timestamps=timestamps, is_lab_mode=True
-    )
+    active = active_counters or [True] * 12
+    reject_count = sum(c for c, flag in zip(counts, active) if flag)
+    capacity_count = object_totals[-1] if object_totals else 0
+    accepts_count = max(0, capacity_count - reject_count)
 
-    accepts_total = a_stats.get("total_capacity_lbs", 0)
-    rejects_total = r_stats.get("total_capacity_lbs", 0)
-    total_capacity = accepts_total + rejects_total
+    mult = _load_lab_weight_multiplier(machine_id)
+    total_capacity = capacity_count * mult
+    accepts_total = accepts_count * mult
+    rejects_total = reject_count * mult
 
     elapsed_seconds = 0
     if timestamps:
         try:
-            start = datetime.fromisoformat(str(timestamps[0]))
-            end = datetime.fromisoformat(str(timestamps[-1]))
-            elapsed_seconds = int((end - start).total_seconds())
+            start = timestamps[0]
+            end = timestamps[-1]
+            if isinstance(start, datetime) and isinstance(end, datetime):
+                elapsed_seconds = int((end - start).total_seconds())
         except Exception:
             elapsed_seconds = 0
 
@@ -2951,17 +2939,10 @@ def _register_callbacks_impl(app):
             else:
                 active_flags = get_active_counter_flags(mid)
 
-                metrics = (
-                    load_lab_totals_metrics(mid, active_counters=active_flags)
-                    if path
-                    else None
-                )
-
                 if path:
                     counts, _, objects = load_lab_totals(mid, active_counters=active_flags)
                 else:
                     counts, objects = [0] * 12, []
-
 
                 reject_count = sum(
                     c for c, active in zip(counts, active_flags) if active
@@ -2969,14 +2950,12 @@ def _register_callbacks_impl(app):
                 capacity_count = objects[-1] if objects else 0
                 accepts_count = max(0, capacity_count - reject_count)
 
-                if metrics:
-                    tot_cap_lbs, acc_lbs, rej_lbs, _ = metrics
-                    total_capacity = convert_capacity_from_lbs(tot_cap_lbs, weight_pref)
-                    accepts = convert_capacity_from_lbs(acc_lbs, weight_pref)
-                    rejects = convert_capacity_from_lbs(rej_lbs, weight_pref)
-                else:
-                    total_capacity = accepts = rejects = 0
-
+                mult = _load_lab_weight_multiplier(mid)
+                total_capacity = convert_capacity_from_lbs(
+                    capacity_count * mult, weight_pref
+                )
+                accepts = convert_capacity_from_lbs(accepts_count * mult, weight_pref)
+                rejects = convert_capacity_from_lbs(reject_count * mult, weight_pref)
 
                 production_data = {
                     "capacity": total_capacity,

--- a/tests/test_load_last_lab_objects.py
+++ b/tests/test_load_last_lab_objects.py
@@ -1,6 +1,7 @@
 import callbacks
 import hourly_data_saving
 import os
+import pytest
 
 def test_load_last_lab_objects(monkeypatch, tmp_path):
     # Prepare temp lab log
@@ -19,4 +20,7 @@ def test_load_last_lab_objects(monkeypatch, tmp_path):
     callbacks._lab_totals_cache.clear()
 
     value = callbacks.load_last_lab_objects(machine_id)
-    assert value == 150
+    assert value == 20
+
+    _, _, objects = callbacks.load_lab_totals(machine_id)
+    assert objects[-1] == pytest.approx(10.42, rel=1e-3)

--- a/tests/test_update_section_1_1.py
+++ b/tests/test_update_section_1_1.py
@@ -168,6 +168,6 @@ def test_update_section_1_1_lab_weight_from_metrics(monkeypatch, tmp_path):
     accept_row = section.children[2]
     reject_row = section.children[3]
 
-    assert "0.90 lb" in accept_row.children[2].children
+    assert "0.94 lb" in accept_row.children[2].children
 
     assert "0.10 lb" in reject_row.children[2].children


### PR DESCRIPTION
## Summary
- derive lab-mode weights from object counts using machine settings
- compute section 1-1 live capacity with same weight multiplier as PDF report
- adjust lab section test expectations
- use per-minute object rates when available to keep lab object totals aligned with report

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b48bce7b083278c326f20f27e934b